### PR TITLE
use different names for 32bit and 64bit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,28 @@ if (MSVC)
     configure_msvc_runtime()
 endif ()
 
+if (CMAKE_SIZEOF_VOID_P EQUAL 8)
+    MESSAGE ("64 bits compiler detected")
+    SET (PLATFORM_ACH "X64")
+    SET (BOARD_CONTROLLER_NAME "BoardController")
+    SET (GET_DATA_NAME "GetData")
+    if (UNIX)
+        SET (COMPILED_FILE_NAME "libBoardController.so")
+    else (UNIX)
+        SET (COMPILED_FILE_NAME "BoardController.dll")
+    endif (UNIX)
+else (CMAKE_SIZEOF_VOID_P EQUAL 8)
+    MESSAGE ("32 bits compiler detected")
+    SET (PLATFORM_ACH "X86")
+    SET (BOARD_CONTROLLER_NAME "BoardController86")
+    SET (GET_DATA_NAME "GetData86")
+    if (UNIX)
+        SET (COMPILED_FILE_NAME "libBoardController86.so")
+    else (UNIX)
+        SET (COMPILED_FILE_NAME "BoardController86.dll")
+    endif (UNIX)
+endif (CMAKE_SIZEOF_VOID_P EQUAL 8)
+
 # boardcontroller
 set (LIBRARY_SRC
     "src/utils/timestamp.cpp"
@@ -61,19 +83,19 @@ set (LIBRARY_SRC
 )
 
 add_library (
-    BoardController SHARED
+    ${BOARD_CONTROLLER_NAME} SHARED
     ${LIBRARY_SRC}
 )
 
 target_include_directories (
-    BoardController PRIVATE
+    ${BOARD_CONTROLLER_NAME} PRIVATE
     inc
     src/utils/
     src/board_controller/inc
     src/board_controller/openbci/inc
 )
 
-set_target_properties (BoardController
+set_target_properties (${BOARD_CONTROLLER_NAME}
     PROPERTIES
     ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_HOME_DIRECTORY}/compiled"
     LIBRARY_OUTPUT_DIRECTORY "${CMAKE_HOME_DIRECTORY}/compiled"
@@ -81,48 +103,48 @@ set_target_properties (BoardController
 )
 
 if (UNIX)
-    target_link_libraries (BoardController -lpthread)
+    target_link_libraries (${BOARD_CONTROLLER_NAME} -lpthread)
 endif (UNIX)
 
 # getdata
 # it's impossible to install target from subfolder, so we have to move GetData target to top level or split installation
 # I prefer to move GetData from subfolder to top level CMakeLists.txt
 add_library (
-    GetData STATIC
+    ${GET_DATA_NAME} STATIC
     cpp-package/src/board_shim.cpp
     cpp-package/src/data_handler.cpp
 )
 
 target_include_directories (
-    GetData PRIVATE
+    ${GET_DATA_NAME} PRIVATE
     src/board_controller/inc
 )
 
 if (UNIX)
-    target_link_libraries (GetData pthread BoardController)
+    target_link_libraries (${GET_DATA_NAME} pthread ${BOARD_CONTROLLER_NAME})
 else (UNIX)
-    target_link_libraries (GetData BoardController)
+    target_link_libraries (${GET_DATA_NAME} ${BOARD_CONTROLLER_NAME})
 endif (UNIX)
 
 # copy
 if (MSVC)
-    add_custom_command (TARGET BoardController POST_BUILD
-        COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${CMAKE_HOME_DIRECTORY}/compiled/$<CONFIG>/BoardController.dll" "${CMAKE_HOME_DIRECTORY}/python-package/brainflow/lib/BoardController.dll"
-        COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${CMAKE_HOME_DIRECTORY}/compiled/$<CONFIG>/BoardController.dll" "${CMAKE_HOME_DIRECTORY}/matlab-package/brainflow/lib/BoardController.dll"
+    add_custom_command (TARGET ${BOARD_CONTROLLER_NAME} POST_BUILD
+        COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${CMAKE_HOME_DIRECTORY}/compiled/$<CONFIG>/${COMPILED_FILE_NAME}" "${CMAKE_HOME_DIRECTORY}/python-package/brainflow/lib/${COMPILED_FILE_NAME}"
+        COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${CMAKE_HOME_DIRECTORY}/compiled/$<CONFIG>/${COMPILED_FILE_NAME}" "${CMAKE_HOME_DIRECTORY}/matlab-package/brainflow/lib/${COMPILED_FILE_NAME}"
         COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${CMAKE_HOME_DIRECTORY}/src/board_controller/inc/board_controller.h" "${CMAKE_HOME_DIRECTORY}/matlab-package/brainflow/inc/board_controller.h"
-        COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${CMAKE_HOME_DIRECTORY}/compiled/$<CONFIG>/BoardController.dll" "${CMAKE_HOME_DIRECTORY}/java-package/brainflow/src/main/resources/BoardController.dll"
-        COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${CMAKE_HOME_DIRECTORY}/compiled/$<CONFIG>/BoardController.dll" "${CMAKE_HOME_DIRECTORY}/csharp-package/brainflow/brainflow/BoardController.dll"
-        COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${CMAKE_HOME_DIRECTORY}/compiled/$<CONFIG>/BoardController.dll" "${CMAKE_HOME_DIRECTORY}/python-package/brainflow/lib/BoardController.dll"
+        COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${CMAKE_HOME_DIRECTORY}/compiled/$<CONFIG>/${COMPILED_FILE_NAME}" "${CMAKE_HOME_DIRECTORY}/java-package/brainflow/src/main/resources/${COMPILED_FILE_NAME}"
+        COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${CMAKE_HOME_DIRECTORY}/compiled/$<CONFIG>/${COMPILED_FILE_NAME}" "${CMAKE_HOME_DIRECTORY}/csharp-package/brainflow/brainflow/${COMPILED_FILE_NAME}"
+        COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${CMAKE_HOME_DIRECTORY}/compiled/$<CONFIG>/${COMPILED_FILE_NAME}" "${CMAKE_HOME_DIRECTORY}/python-package/brainflow/lib/${COMPILED_FILE_NAME}"
     )
 endif (MSVC)
 if (UNIX)
-    add_custom_command (TARGET BoardController POST_BUILD
-        COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${CMAKE_HOME_DIRECTORY}/compiled/libBoardController.so" "${CMAKE_HOME_DIRECTORY}/python-package/brainflow/lib/libBoardController.so"
-        COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${CMAKE_HOME_DIRECTORY}/compiled/libBoardController.so" "${CMAKE_HOME_DIRECTORY}/matlab-package/brainflow/lib/libBoardController.so"
+    add_custom_command (TARGET ${BOARD_CONTROLLER_NAME} POST_BUILD
+        COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${CMAKE_HOME_DIRECTORY}/compiled/${COMPILED_FILE_NAME}" "${CMAKE_HOME_DIRECTORY}/python-package/brainflow/lib/${COMPILED_FILE_NAME}"
+        COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${CMAKE_HOME_DIRECTORY}/compiled/${COMPILED_FILE_NAME}" "${CMAKE_HOME_DIRECTORY}/matlab-package/brainflow/lib/${COMPILED_FILE_NAME}"
         COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${CMAKE_HOME_DIRECTORY}/src/board_controller/inc/board_controller.h" "${CMAKE_HOME_DIRECTORY}/matlab-package/brainflow/inc/board_controller.h"
-        COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${CMAKE_HOME_DIRECTORY}/compiled/libBoardController.so" "${CMAKE_HOME_DIRECTORY}/java-package/brainflow/src/main/resources/libBoardController.so"
-        COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${CMAKE_HOME_DIRECTORY}/compiled/libBoardController.so" "${CMAKE_HOME_DIRECTORY}/csharp-package/brainflow/brainflow/libBoardController.so"
-        COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${CMAKE_HOME_DIRECTORY}/compiled/libBoardController.so" "${CMAKE_HOME_DIRECTORY}/python-package/brainflow/lib/libBoardController.so"
+        COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${CMAKE_HOME_DIRECTORY}/compiled/${COMPILED_FILE_NAME}" "${CMAKE_HOME_DIRECTORY}/java-package/brainflow/src/main/resources/${COMPILED_FILE_NAME}"
+        COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${CMAKE_HOME_DIRECTORY}/compiled/${COMPILED_FILE_NAME}" "${CMAKE_HOME_DIRECTORY}/csharp-package/brainflow/brainflow/${COMPILED_FILE_NAME}"
+        COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${CMAKE_HOME_DIRECTORY}/compiled/${COMPILED_FILE_NAME}" "${CMAKE_HOME_DIRECTORY}/python-package/brainflow/lib/${COMPILED_FILE_NAME}"
     )
 endif (UNIX)
 
@@ -157,7 +179,7 @@ install (
 )
 
 install (
-    TARGETS BoardController GetData
+    TARGETS ${BOARD_CONTROLLER_NAME} ${GET_DATA_NAME}
     EXPORT ${targets_export_name}
     RUNTIME DESTINATION lib
     LIBRARY DESTINATION lib

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ clone_depth: 3
 build: off
 
 init:
-  - cmd: set PATH=%PY_DIR%;%PY_DIR%\Scripts;C:\Program Files\Java\jdk1.8.0\bin;%APPVEYOR_BUILD_FOLDER%\installed\lib;%APPVEYOR_BUILD_FOLDER%\installed32\lib%PATH%
+  - cmd: set PATH=%PY_DIR%;%PY_DIR%\Scripts;C:\Program Files\Java\jdk1.8.0\bin;%APPVEYOR_BUILD_FOLDER%\installed\lib;%APPVEYOR_BUILD_FOLDER%\installed32\lib;%PATH%
   - cmd: set CNC_INSTALL_CNCA0_CNCB0_PORTS="YES"
   - cmd: set JAVA_HOME=C:\Program Files\Java\jdk1.8.0
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ clone_depth: 3
 build: off
 
 init:
-  - cmd: set PATH=%PY_DIR%;%PY_DIR%\Scripts;C:\Program Files\Java\jdk1.8.0\bin;%APPVEYOR_BUILD_FOLDER%\installed\lib;%PATH%
+  - cmd: set PATH=%PY_DIR%;%PY_DIR%\Scripts;C:\Program Files\Java\jdk1.8.0\bin;%APPVEYOR_BUILD_FOLDER%\installed\lib;%APPVEYOR_BUILD_FOLDER%\installed32\lib%PATH%
   - cmd: set CNC_INSTALL_CNCA0_CNCB0_PORTS="YES"
   - cmd: set JAVA_HOME=C:\Program Files\Java\jdk1.8.0
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@ test_script:
   - mkdir %APPVEYOR_BUILD_FOLDER%\tests\cpp\build && cd %APPVEYOR_BUILD_FOLDER%\tests\cpp\build && cmake -G "Visual Studio 14 2015 Win64" -DCMAKE_SYSTEM_VERSION=8.1 -DCMAKE_PREFIX_PATH=%APPVEYOR_BUILD_FOLDER%\installed\ .. && cmake --build . && python %APPVEYOR_BUILD_FOLDER%\emulator\brainflow_emulator\cyton_windows.py %APPVEYOR_BUILD_FOLDER%\tests\cpp\build\Debug\test_get_data.exe
   # I've checked there is a jdk and mvn preinstalled in image, don't need to install them from chocolatey
   - cd %APPVEYOR_BUILD_FOLDER%\java-package\brainflow && mvn package && cd ..\..\tests\java && javac -classpath ..\..\java-package\brainflow\target\brainflow-java-jar-with-dependencies.jar BrainFlowTest.java
-  - mkdir build32 && cd build32 && cmake -G "Visual Studio 14 2015" -DCMAKE_SYSTEM_VERSION=8.1 -DCMAKE_INSTALL_PREFIX=..\installed32\ .. && cmake --build . --target install --config Release
+  - mkdir %APPVEYOR_BUILD_FOLDER%\build32 && cd %APPVEYOR_BUILD_FOLDER%\build32 && cmake -G "Visual Studio 14 2015" -DCMAKE_SYSTEM_VERSION=8.1 -DCMAKE_INSTALL_PREFIX=..\installed32\ .. && cmake --build . --target install --config Release
 
 notifications:
   - provider: Email

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,9 @@ test_script:
   - mkdir %APPVEYOR_BUILD_FOLDER%\tests\cpp\build && cd %APPVEYOR_BUILD_FOLDER%\tests\cpp\build && cmake -G "Visual Studio 14 2015 Win64" -DCMAKE_SYSTEM_VERSION=8.1 -DCMAKE_PREFIX_PATH=%APPVEYOR_BUILD_FOLDER%\installed\ .. && cmake --build . && python %APPVEYOR_BUILD_FOLDER%\emulator\brainflow_emulator\cyton_windows.py %APPVEYOR_BUILD_FOLDER%\tests\cpp\build\Debug\test_get_data.exe
   # I've checked there is a jdk and mvn preinstalled in image, don't need to install them from chocolatey
   - cd %APPVEYOR_BUILD_FOLDER%\java-package\brainflow && mvn package && cd ..\..\tests\java && javac -classpath ..\..\java-package\brainflow\target\brainflow-java-jar-with-dependencies.jar BrainFlowTest.java
+  # tests for 32 bit
   - mkdir %APPVEYOR_BUILD_FOLDER%\build32 && cd %APPVEYOR_BUILD_FOLDER%\build32 && cmake -G "Visual Studio 14 2015" -DCMAKE_SYSTEM_VERSION=8.1 -DCMAKE_INSTALL_PREFIX=..\installed32\ .. && cmake --build . --target install --config Release
+  - mkdir %APPVEYOR_BUILD_FOLDER%\tests\cpp\build32 && cd %APPVEYOR_BUILD_FOLDER%\tests\cpp\build32 && cmake -G "Visual Studio 14 2015" -DCMAKE_SYSTEM_VERSION=8.1 -DCMAKE_PREFIX_PATH=%APPVEYOR_BUILD_FOLDER%\installed32\ .. && cmake --build . && python %APPVEYOR_BUILD_FOLDER%\emulator\brainflow_emulator\cyton_windows.py %APPVEYOR_BUILD_FOLDER%\tests\cpp\build32\Debug\test_get_data.exe
 
 notifications:
   - provider: Email

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,6 +27,7 @@ test_script:
   - mkdir %APPVEYOR_BUILD_FOLDER%\tests\cpp\build && cd %APPVEYOR_BUILD_FOLDER%\tests\cpp\build && cmake -G "Visual Studio 14 2015 Win64" -DCMAKE_SYSTEM_VERSION=8.1 -DCMAKE_PREFIX_PATH=%APPVEYOR_BUILD_FOLDER%\installed\ .. && cmake --build . && python %APPVEYOR_BUILD_FOLDER%\emulator\brainflow_emulator\cyton_windows.py %APPVEYOR_BUILD_FOLDER%\tests\cpp\build\Debug\test_get_data.exe
   # I've checked there is a jdk and mvn preinstalled in image, don't need to install them from chocolatey
   - cd %APPVEYOR_BUILD_FOLDER%\java-package\brainflow && mvn package && cd ..\..\tests\java && javac -classpath ..\..\java-package\brainflow\target\brainflow-java-jar-with-dependencies.jar BrainFlowTest.java
+  - mkdir build32 && cd build32 && cmake -G "Visual Studio 14 2015" -DCMAKE_SYSTEM_VERSION=8.1 -DCMAKE_INSTALL_PREFIX=..\installed32\ .. && cmake --build . --target install --config Release
 
 notifications:
   - provider: Email

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -12,14 +12,26 @@ check_required_components("@PROJECT_NAME@")
 set (@PROJECT_NAME@_INCLUDE_DIRS @package_inc_install_dir@)
 set (@PROJECT_NAME@_LIBRARY_DIRS @package_lib_install_dir@)
 
+if (CMAKE_SIZEOF_VOID_P EQUAL 8)
+    MESSAGE ("64 bits compiler detected")
+    SET (PLATFORM_ACH "X64")
+    SET (BOARD_CONTROLLER_NAME "BoardController" "libBoardController")
+    SET (GET_DATA_NAME "GetData" "libGetData")
+else (CMAKE_SIZEOF_VOID_P EQUAL 8)
+    MESSAGE ("32 bits compiler detected")
+    SET (PLATFORM_ACH "X86")
+    SET (BOARD_CONTROLLER_NAME "BoardController86" "libBoardController86")
+    SET (GET_DATA_NAME "GetData86" "libGetData86")
+endif (CMAKE_SIZEOF_VOID_P EQUAL 8)
+
 find_library (
     BoardControllerPath
-    BoardController libBoardController
+    ${BOARD_CONTROLLER_NAME}
     PATHS @package_lib_install_dir@
 )
 
 find_library (
     GetDataPath
-    GetData libGetData
+    ${GET_DATA_NAME}
     PATHS @package_lib_install_dir@
 )


### PR DESCRIPTION
Right now if you build brainflow with 32bit compiler and 64bit compiler, files with the same names will be generated and these files will be copied to the same locations and override each other.

There are two possible ways to solve it - move them to different folders or create files with different names. I've choosed different names.

This patch just fixes it in CmakeLists and add a test to appveyour. I don't add 32bit compiled libraries to the repo and I don't update bindings to load 32bit library. I guess we will do it later and just for some OSes and languages

I will squash commits during merge