### PR TITLE
Novaxr add check that streaming was started

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,14 +31,15 @@ before_script:
   - sudo -H pip3 install $TRAVIS_BUILD_DIR/python-package
   - cd $TRAVIS_BUILD_DIR/r-package/brainflow && sudo -H R CMD build . && sudo -H R CMD INSTALL brainflow_0.0.0.9000.tar.gz
   - cd $TRAVIS_BUILD_DIR/tests/cpp && mkdir build && cd build && cmake -DCMAKE_PREFIX_PATH=$TRAVIS_BUILD_DIR/installed .. && make
+  - cd $TRAVIS_BUILD_DIR && cd java-package/brainflow && mvn package
 
 script:
   # tests for cyton
   - sudo -H python3 $TRAVIS_BUILD_DIR/emulator/brainflow_emulator/cyton_linux.py python3 $TRAVIS_BUILD_DIR/tests/python/brainflow_get_data.py --log --board 0 --port 
-  # Disable this test temporary, dont know whats wrong can not reproduce locally, will investigate later
-  #- cd $TRAVIS_BUILD_DIR && cd java-package/brainflow && mvn package && cd $TRAVIS_BUILD_DIR/tests/java/ && sudo -H javac -classpath $TRAVIS_BUILD_DIR/java-package/brainflow/target/brainflow-java-jar-with-dependencies.jar BrainFlowTest.java && ls -l . && sudo -H python3 $TRAVIS_BUILD_DIR/emulator/brainflow_emulator/cyton_linux.py java -classpath ".:$TRAVIS_BUILD_DIR/java-package/brainflow/target/brainflow-java-jar-with-dependencies.jar" BrainFlowTest 0
   - sudo -H python3 $TRAVIS_BUILD_DIR/emulator/brainflow_emulator/cyton_linux.py Rscript $TRAVIS_BUILD_DIR/tests/r/brainflow_get_data.R
   - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$TRAVIS_BUILD_DIR/installed/lib python3 $TRAVIS_BUILD_DIR/emulator/brainflow_emulator/cyton_linux.py $TRAVIS_BUILD_DIR/tests/cpp/build/test_get_data 0
+  # temp disable java test
+  # - cd $TRAVIS_BUILD_DIR/tests/java/ && sudo -H javac -classpath $TRAVIS_BUILD_DIR/java-package/brainflow/target/brainflow-java-jar-with-dependencies.jar BrainFlowTest.java && ls -l . && sudo -H python3 $TRAVIS_BUILD_DIR/emulator/brainflow_emulator/cyton_linux.py java -classpath ".:$TRAVIS_BUILD_DIR/java-package/brainflow/target/brainflow-java-jar-with-dependencies.jar" BrainFlowTest 0
   # tests for synthetic board
   - python3 $TRAVIS_BUILD_DIR/tests/python/brainflow_get_data.py --log --board -1 --port "smth"
   - $TRAVIS_BUILD_DIR/tests/cpp/build/test_get_data -1 "smth"

--- a/emulator/brainflow_emulator/novaxr.py
+++ b/emulator/brainflow_emulator/novaxr.py
@@ -72,6 +72,7 @@ class NovaXREmulator (threading.Thread):
             if self.state == State.stream.value:
                 package = list ()
                 package.append (self.package_num)
+                self.package_num = self.package_num + 1
                 for i in range (1, self.package_size):
                     package.append (random.randint (0, 255))
                     try:

--- a/java-package/brainflow/src/main/java/NOVAXR.java
+++ b/java-package/brainflow/src/main/java/NOVAXR.java
@@ -1,0 +1,7 @@
+
+public interface NOVAXR {
+	public final static int board_id = 3;
+	public final static int fs_hz = 2000;
+	public final static int num_eeg_channels = 16;
+	public final static int package_length = 20;
+}

--- a/src/board_controller/openbci/ganglion.cpp
+++ b/src/board_controller/openbci/ganglion.cpp
@@ -145,7 +145,7 @@ int Ganglion::start_stream (int buffer_size)
         Board::board_logger->error ("no data received in 20sec, stopping thread");
         this->is_streaming = true;
         this->stop_stream ();
-        return this->state;
+        return UNABLE_TO_OPEN_PORT_ERROR;
     }
 }
 

--- a/src/board_controller/openbci/ganglion.cpp
+++ b/src/board_controller/openbci/ganglion.cpp
@@ -145,6 +145,7 @@ int Ganglion::start_stream (int buffer_size)
         Board::board_logger->error ("no data received in 20sec, stopping thread");
         this->is_streaming = true;
         this->stop_stream ();
+        // return the same exit code as novaxr
         return UNABLE_TO_OPEN_PORT_ERROR;
     }
 }

--- a/src/board_controller/openbci/inc/novaxr.h
+++ b/src/board_controller/openbci/inc/novaxr.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <condition_variable>
+#include <mutex>
 #include <thread>
 
 #include "board.h"
@@ -17,6 +19,9 @@ private:
     int num_channels;
     Socket socket;
 
+    std::mutex m;
+    std::condition_variable cv;
+    volatile int state;
     void read_thread ();
 
 public:

--- a/src/board_controller/openbci/novaxr.cpp
+++ b/src/board_controller/openbci/novaxr.cpp
@@ -84,6 +84,8 @@ int NovaXR::start_stream (int buffer_size)
         Board::board_logger->error ("no data received in 5sec, stopping thread");
         this->is_streaming = true;
         this->stop_stream ();
+        // more likely error occured due to wrong ip address, return UNABLE_TO_OPEN_PORT instead
+        // SYNC_TIMEOUT_ERROR
         return UNABLE_TO_OPEN_PORT_ERROR;
     }
 }


### PR DESCRIPTION
- add missed file for java
- add check that streaming was started
- fix wrong num channels for novaxr
- fix wrong package num in novaxr emulator
- if streaming is not running return UNABLE_TO_OPEN_PORT instead SYNC_TIMEOUT_ERROR