### PR TITLE
add set_log_file method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ before_script:
       docker pull dockcross/manylinux-x64 ;
     fi
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then
-      docker run -e TRAVIS_BUILD_DIR=$TRAVIS_BUILD_DIR -v $TRAVIS_BUILD_DIR:$TRAVIS_BUILD_DIR dockcross/manylinux-x64 /bin/bash -c "/opt/python/cp36-cp36m/bin/pip3.6 install cmake && cd $TRAVIS_BUILD_DIR && mkdir build && cd build && cmake -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/installed .. && make && make install" ;
+      docker run -e TRAVIS_BUILD_DIR=$TRAVIS_BUILD_DIR -v $TRAVIS_BUILD_DIR:$TRAVIS_BUILD_DIR dockcross/manylinux-x64 /bin/bash -c "/opt/python/cp36-cp36m/bin/pip3.6 install cmake==3.13.0 && cd $TRAVIS_BUILD_DIR && mkdir build && cd build && cmake -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/installed .. && make && make install" ;
     fi
   # build for mac
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then

--- a/cpp-package/src/board_shim.cpp
+++ b/cpp-package/src/board_shim.cpp
@@ -4,6 +4,42 @@
 #include "board_controller.h"
 #include "board_shim.h"
 
+void BoardShim::enable_board_logger ()
+{
+    int res = set_log_level (2);
+    if (res != STATUS_OK)
+    {
+        throw BrainFlowException ("failed to enable board logger", res);
+    }
+}
+
+void BoardShim::disable_board_logger ()
+{
+    int res = set_log_level (6);
+    if (res != STATUS_OK)
+    {
+        throw BrainFlowException ("failed to disable board logger", res);
+    }
+}
+
+void BoardShim::enable_dev_board_logger ()
+{
+    int res = set_log_level (0);
+    if (res != STATUS_OK)
+    {
+        throw BrainFlowException ("failed to enable dev board logger", res);
+    }
+}
+
+void BoardShim::set_log_file (char *log_file)
+{
+    int res = ::set_log_file (log_file);
+    if (res != STATUS_OK)
+    {
+        throw BrainFlowException ("failed to set log file", res);
+    }
+}
+
 BoardShim::BoardShim (int board_id, const char *port_name)
 {
     strcpy (this->port_name, port_name);

--- a/cpp-package/src/board_shim.h
+++ b/cpp-package/src/board_shim.h
@@ -9,6 +9,11 @@ class BoardShim
     void reshape_data (int data_count, float *buf, double *ts_buf, double **output_buf);
 
 public:
+    static void disable_board_logger ();
+    static void enable_board_logger ();
+    static void enable_dev_board_logger ();
+    static void set_log_file (char *log_file);
+
     int num_data_channels;
     int board_id;
     char port_name[1024];

--- a/csharp-package/brainflow/brainflow/board_shim.cs
+++ b/csharp-package/brainflow/brainflow/board_shim.cs
@@ -49,6 +49,15 @@ namespace brainflow
             }
         }
 
+        public static void set_log_file (string log_file)
+        {
+            int res = Library.set_log_file (log_file);
+            if (res != (int)CustomExitCodes.STATUS_OK)
+            {
+                throw new BrainFlowExceptioin (res);
+            }
+        }
+
         public void prepare_session ()
         {
             int res = Library.prepare_session (board_id, port_name);

--- a/csharp-package/brainflow/brainflow/library.cs
+++ b/csharp-package/brainflow/brainflow/library.cs
@@ -59,6 +59,8 @@ namespace brainflow
         public static extern int set_log_level (int log_level);
         [DllImport ("BoardController.dll", SetLastError = true)]
         public static extern int config_board (string config, int board_id, string port_name);
+        [DllImport ("BoardController.dll", SetLastError = true)]
+        public static extern int set_log_file (string log_file);
     }
 
     public static class Library32
@@ -81,6 +83,8 @@ namespace brainflow
         public static extern int set_log_level (int log_level);
         [DllImport ("BoardController32.dll", SetLastError = true)]
         public static extern int config_board (string config, int board_id, string port_name);
+        [DllImport ("BoardController32.dll", SetLastError = true)]
+        public static extern int set_log_file (string log_file);
     }
 
     public static class Library
@@ -155,6 +159,14 @@ namespace brainflow
                 return Library64.config_board (config, board_id, port_name);
             else
                 return Library32.config_board (config, board_id, port_name);
+        }
+
+        public static int set_log_file (string log_file)
+        {
+            if (System.Environment.Is64BitProcess)
+                return Library64.set_log_file (log_file);
+            else
+                return Library32.set_log_file (log_file);
         }
     }
 }

--- a/csharp-package/brainflow/test/get_board_data.cs
+++ b/csharp-package/brainflow/test/get_board_data.cs
@@ -8,6 +8,7 @@ namespace test
         static void Main (string[] args)
         {
             BoardShim.enable_dev_board_logger ();
+            BoardShim.set_log_file ("test.txt");
             BoardShim board_shim;
             if (args.Length == 2)
                 board_shim = new BoardShim (Int32.Parse(args[0]), args[1]);

--- a/csharp-package/brainflow/test/get_board_data.cs
+++ b/csharp-package/brainflow/test/get_board_data.cs
@@ -8,7 +8,6 @@ namespace test
         static void Main (string[] args)
         {
             BoardShim.enable_dev_board_logger ();
-            BoardShim.set_log_file ("test.txt");
             BoardShim board_shim;
             if (args.Length == 2)
                 board_shim = new BoardShim (Int32.Parse(args[0]), args[1]);

--- a/java-package/brainflow/src/main/java/brainflow/BoardShim.java
+++ b/java-package/brainflow/src/main/java/brainflow/BoardShim.java
@@ -27,6 +27,7 @@ public class BoardShim {
         int get_board_data_count (int[] result, int board_id, String port_name);
         int get_board_data (int data_count, float[] data_buf, double[] ts_buf, int board_id, String port_name);
         int set_log_level (int log_level);
+        int set_log_file (String log_file);
     }
 
     public int package_length;
@@ -142,7 +143,7 @@ public class BoardShim {
         return new BoardData (package_length, data_arr, ts_arr);
     }
 
-    public void set_log_level (int log_level) throws BrainFlowError {
+    private void set_log_level (int log_level) throws BrainFlowError {
         int ec = this.instance.set_log_level (log_level);
         if (ec != ExitCode.STATUS_OK.get_code ()) {
             throw new BrainFlowError ("Error in set_log_level", ec);
@@ -159,5 +160,12 @@ public class BoardShim {
 
     public void disable_board_logger () throws BrainFlowError {
         set_log_level (6);
+    }
+
+    public void set_log_file (String log_file) throws BrainFlowError {
+        int ec = this.instance.set_log_file (log_file);
+        if (ec != ExitCode.STATUS_OK.get_code ()) {
+            throw new BrainFlowError ("Error in set_log_file", ec);
+        }
     }
 }

--- a/java-package/brainflow/src/main/java/brainflow/BoardShim.java
+++ b/java-package/brainflow/src/main/java/brainflow/BoardShim.java
@@ -7,8 +7,6 @@ import java.nio.file.StandardCopyOption;
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.Arrays;
-import java.util.jar.JarEntry;
-import java.util.jar.JarFile;
 
 import org.apache.commons.lang3.SystemUtils;
 

--- a/java-package/brainflow/src/main/java/brainflow/BoardShim.java
+++ b/java-package/brainflow/src/main/java/brainflow/BoardShim.java
@@ -53,17 +53,17 @@ public class BoardShim {
     
     private static void unpack_from_jar (String lib_name)
     {
-    	try
-    	{
-	        File file = new File (lib_name);
-	        if (file.exists ())
-	            file.delete ();
-	        InputStream link = (BoardShim.class.getResourceAsStream (lib_name));
-	        Files.copy (link, file.getAbsoluteFile ().toPath ());
-    	} catch (Exception io)
-    	{
-    		System.err.println ("native library: " + lib_name + " is not found in jar file");
-    	}
+        try
+        {
+            File file = new File (lib_name);
+            if (file.exists ())
+                file.delete ();
+            InputStream link = (BoardShim.class.getResourceAsStream (lib_name));
+            Files.copy (link, file.getAbsoluteFile ().toPath ());
+        } catch (Exception io)
+        {
+            System.err.println ("native library: " + lib_name + " is not found in jar file");
+        }
     }
     
     public static void enable_board_logger () throws BrainFlowError {

--- a/java-package/brainflow/src/main/java/brainflow/BoardShim.java
+++ b/java-package/brainflow/src/main/java/brainflow/BoardShim.java
@@ -2,13 +2,13 @@ package brainflow;
 
 import java.io.File;
 import java.io.InputStream;
-import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.Arrays;
-import java.util.Map;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
 
 import org.apache.commons.lang3.SystemUtils;
 
@@ -17,7 +17,7 @@ import com.sun.jna.Native;
 
 public class BoardShim {
 
-    public interface DllInterface extends Library {
+    private interface DllInterface extends Library {
         int prepare_session (int board_id, String port_name);
         int config_board (String config, int board_id, String port_name);
         int start_stream (int buffer_size, int board_id, String port_name);
@@ -29,15 +29,9 @@ public class BoardShim {
         int set_log_level (int log_level);
         int set_log_file (String log_file);
     }
+    private static DllInterface instance;
 
-    public int package_length;
-    public int board_id;
-    public String port_name;
-    public DllInterface instance;
-    public BoardShim (int board_id, String port_name, Boolean unpack_lib) throws BrainFlowError, IOException, ReflectiveOperationException {
-        this.board_id = board_id;
-        package_length = BoardInfoGetter.get_package_length(board_id);
-        
+    static {
         String lib_name = "libBoardController.so";
         if (SystemUtils.IS_OS_WINDOWS)
         {
@@ -49,59 +43,96 @@ public class BoardShim {
             lib_name = "libBoardController.dylib";
         }
 
-        if (unpack_lib)
+        // need to extract libraries from jar
+        unpack_from_jar (lib_name);
+        if (SystemUtils.IS_OS_WINDOWS)
         {
-            // need to extract libraries from jar
-            unpack_from_jar (lib_name);
-            if (SystemUtils.IS_OS_WINDOWS)
-            {
-                unpack_from_jar ("GanglionLib.dll");
-                unpack_from_jar ("GanglionLibNative64.dll");
-            }
+            unpack_from_jar ("GanglionLib.dll");
+            unpack_from_jar ("GanglionLibNative64.dll");
         }
-        this.instance = (DllInterface) Native.loadLibrary (lib_name, DllInterface.class);
-        this.port_name = port_name;
+        instance = (DllInterface) Native.loadLibrary (lib_name, DllInterface.class);
     }
     
-    private void unpack_from_jar (String lib_name) throws IOException
+    private static void unpack_from_jar (String lib_name)
     {
-        File file = new File (lib_name);
-        if (file.exists ())
-            file.delete ();
-        InputStream link = (getClass().getResourceAsStream (lib_name));
-        Files.copy (link, file.getAbsoluteFile ().toPath ());
+    	try
+    	{
+	        File file = new File (lib_name);
+	        if (file.exists ())
+	            file.delete ();
+	        InputStream link = (BoardShim.class.getResourceAsStream (lib_name));
+	        Files.copy (link, file.getAbsoluteFile ().toPath ());
+    	} catch (Exception io)
+    	{
+    		System.err.println ("native library: " + lib_name + " is not found in jar file");
+    	}
+    }
+    
+    public static void enable_board_logger () throws BrainFlowError {
+        set_log_level (2);
+    }
+
+    public static void enable_dev_board_logger () throws BrainFlowError {
+        set_log_level (0);
+    }
+
+    public static void disable_board_logger () throws BrainFlowError {
+        set_log_level (6);
+    }
+
+    public static void set_log_file (String log_file) throws BrainFlowError {
+        int ec = instance.set_log_file (log_file);
+        if (ec != ExitCode.STATUS_OK.get_code ()) {
+            throw new BrainFlowError ("Error in set_log_file", ec);
+        }
+    }
+    
+    private static void set_log_level (int log_level) throws BrainFlowError {
+        int ec = instance.set_log_level (log_level);
+        if (ec != ExitCode.STATUS_OK.get_code ()) {
+            throw new BrainFlowError ("Error in set_log_level", ec);
+        }
+    }
+    
+    private int package_length;
+    public int board_id;
+    public String port_name;
+    public BoardShim (int board_id, String port_name) throws BrainFlowError, IOException, ReflectiveOperationException {
+        this.board_id = board_id;
+        package_length = BoardInfoGetter.get_package_length(board_id);
+        this.port_name = port_name;
     }
 
     public void prepare_session () throws BrainFlowError {
-        int ec = this.instance.prepare_session (board_id, port_name);
+        int ec = instance.prepare_session (board_id, port_name);
         if (ec != ExitCode.STATUS_OK.get_code ()) {
             throw new BrainFlowError ("Error in prepare_session", ec);
         }
     }
 
     public void config_board (String config) throws BrainFlowError {
-        int ec = this.instance.config_board (config, board_id, port_name);
+        int ec = instance.config_board (config, board_id, port_name);
         if (ec != ExitCode.STATUS_OK.get_code ()) {
             throw new BrainFlowError ("Error in config_board", ec);
         }
     }
 
     public void start_stream (int buffer_size) throws BrainFlowError {
-        int ec = this.instance.start_stream (buffer_size, board_id, port_name);
+        int ec = instance.start_stream (buffer_size, board_id, port_name);
         if (ec != ExitCode.STATUS_OK.get_code ()) {
             throw new BrainFlowError ("Error in start_stream", ec);
         }
     }
 
     public void stop_stream () throws BrainFlowError {
-        int ec = this.instance.stop_stream (board_id, port_name);
+        int ec = instance.stop_stream (board_id, port_name);
         if (ec != ExitCode.STATUS_OK.get_code ()) {
             throw new BrainFlowError ("Error in stop_stream", ec);
         }
     }
 
     public void release_session () throws BrainFlowError {
-        int ec = this.instance.release_session (board_id, port_name);
+        int ec = instance.release_session (board_id, port_name);
         if (ec != ExitCode.STATUS_OK.get_code ()) {
             throw new BrainFlowError ("Error in release_session", ec);
         }
@@ -109,7 +140,7 @@ public class BoardShim {
 
     public int get_board_data_count () throws BrainFlowError {
         int[] res = new int[1];
-        int ec = this.instance.get_board_data_count (res, board_id, port_name);
+        int ec = instance.get_board_data_count (res, board_id, port_name);
         if (ec != ExitCode.STATUS_OK.get_code ()) {
             throw new BrainFlowError ("Error in get_board_data_count", ec);
         }
@@ -120,7 +151,7 @@ public class BoardShim {
         float[] data_arr = new float[num_samples * package_length];
         double[] ts_arr = new double[num_samples];
         int[] current_size = new int[1];
-        int ec = this.instance.get_current_board_data (num_samples, data_arr, ts_arr, current_size, board_id, port_name);
+        int ec = instance.get_current_board_data (num_samples, data_arr, ts_arr, current_size, board_id, port_name);
         if (ec != ExitCode.STATUS_OK.get_code ()) {
             throw new BrainFlowError ("Error in get_current_board_data", ec);
         }
@@ -136,36 +167,10 @@ public class BoardShim {
         int size = get_board_data_count ();
         float[] data_arr = new float[size * package_length];
         double[] ts_arr = new double[size];
-        int ec = this.instance.get_board_data (size, data_arr, ts_arr, board_id, port_name);
+        int ec = instance.get_board_data (size, data_arr, ts_arr, board_id, port_name);
         if (ec != ExitCode.STATUS_OK.get_code ()) {
             throw new BrainFlowError ("Error in get_board_data", ec);
         }
         return new BoardData (package_length, data_arr, ts_arr);
-    }
-
-    private void set_log_level (int log_level) throws BrainFlowError {
-        int ec = this.instance.set_log_level (log_level);
-        if (ec != ExitCode.STATUS_OK.get_code ()) {
-            throw new BrainFlowError ("Error in set_log_level", ec);
-        }
-    }
-
-    public void enable_board_logger () throws BrainFlowError {
-        set_log_level (2);
-    }
-
-    public void enable_dev_board_logger () throws BrainFlowError {
-        set_log_level (0);
-    }
-
-    public void disable_board_logger () throws BrainFlowError {
-        set_log_level (6);
-    }
-
-    public void set_log_file (String log_file) throws BrainFlowError {
-        int ec = this.instance.set_log_file (log_file);
-        if (ec != ExitCode.STATUS_OK.get_code ()) {
-            throw new BrainFlowError ("Error in set_log_file", ec);
-        }
     }
 }

--- a/java-package/brainflow/src/main/java/brainflow/BrainFlowError.java
+++ b/java-package/brainflow/src/main/java/brainflow/BrainFlowError.java
@@ -6,7 +6,7 @@ public class BrainFlowError extends Exception {
     
     public BrainFlowError (String message, int ec)
     {
-        super (message + ":" + brainflow.ExitCode.string_from_code(ec));
+        super (message + ":" + brainflow.ExitCode.string_from_code (ec));
         exit_code = ec;
         msg = message;
     }

--- a/java-package/brainflow/src/main/java/brainflow/BrainFlowError.java
+++ b/java-package/brainflow/src/main/java/brainflow/BrainFlowError.java
@@ -6,7 +6,7 @@ public class BrainFlowError extends Exception {
     
     public BrainFlowError (String message, int ec)
     {
-        super (message + ":" + ExitCode.string_from_code (ec));
+        super (message + ":" + brainflow.ExitCode.string_from_code(ec));
         exit_code = ec;
         msg = message;
     }

--- a/java-package/brainflow/src/test/java/brainflow/BrainFlowTest.java
+++ b/java-package/brainflow/src/test/java/brainflow/BrainFlowTest.java
@@ -4,8 +4,8 @@ public class BrainFlowTest {
 
     public static void main (String[] args) throws Exception {
 
-        BoardShim.enable_board_logger();
-        BoardShim.set_log_file("test_log.txt");
+        BoardShim.enable_board_logger ();
+        BoardShim.set_log_file ("test_log.txt");
         BoardShim board_shim = new BoardShim (Integer.parseInt (args[0]), args[1]);
         board_shim.prepare_session ();
         System.out.println ("Session is ready");

--- a/java-package/brainflow/src/test/java/brainflow/BrainFlowTest.java
+++ b/java-package/brainflow/src/test/java/brainflow/BrainFlowTest.java
@@ -4,7 +4,9 @@ public class BrainFlowTest {
 
     public static void main (String[] args) throws Exception {
 
-        BoardShim board_shim = new BoardShim (Integer.parseInt (args[0]), args[1], true);
+    	BoardShim.enable_board_logger();
+    	BoardShim.set_log_file("test_log.txt");
+        BoardShim board_shim = new BoardShim (Integer.parseInt (args[0]), args[1]);
         board_shim.prepare_session ();
         System.out.println ("Session is ready");
         board_shim.start_stream (3600);

--- a/java-package/brainflow/src/test/java/brainflow/BrainFlowTest.java
+++ b/java-package/brainflow/src/test/java/brainflow/BrainFlowTest.java
@@ -4,8 +4,8 @@ public class BrainFlowTest {
 
     public static void main (String[] args) throws Exception {
 
-    	BoardShim.enable_board_logger();
-    	BoardShim.set_log_file("test_log.txt");
+        BoardShim.enable_board_logger();
+        BoardShim.set_log_file("test_log.txt");
         BoardShim board_shim = new BoardShim (Integer.parseInt (args[0]), args[1]);
         board_shim.prepare_session ();
         System.out.println ("Session is ready");

--- a/matlab-package/BoardShim.m
+++ b/matlab-package/BoardShim.m
@@ -107,6 +107,12 @@ classdef BoardShim
             obj.check_ec (exit_code, task_name);
         end
 
+        function set_log_file (obj, log_file)
+            task_name = 'set_log_file';
+            exit_code = calllib (obj.libname, task_name, log_file);
+            obj.check_ec (exit_code, task_name);
+        end
+
         function enable_board_logger (obj)
             set_log_level (2)
         end

--- a/matlab-package/BrainflowGetData.m
+++ b/matlab-package/BrainflowGetData.m
@@ -1,4 +1,4 @@
-board_shim = BoardShim (BoardIDs.GANGLION_BOARD, '');
+board_shim = BoardShim (BoardIDs.SYNTHETIC_BOARD, '');
 board_shim.prepare_session ();
 board_shim.start_stream (3600);
 pause (5)

--- a/python-package/brainflow/board_shim.py
+++ b/python-package/brainflow/board_shim.py
@@ -197,6 +197,12 @@ class BoardControllerDLL (object):
            ctypes.c_int
         ]
 
+        self.set_log_file = self.lib.set_log_file
+        self.set_log_file.restype = ctypes.c_int
+        self.set_log_file.argtypes = [
+            ctypes.c_char_p
+        ]
+
         self.config_board = self.lib.config_board
         self.config_board.restype = ctypes.c_int
         self.config_board.argtypes = [
@@ -242,6 +248,17 @@ class BoardShim (object):
         res = BoardControllerDLL.get_instance ().set_log_level (0)
         if res != StreamExitCodes.STATUS_OK.value:
             raise BrainFlowError ('unable to enable logger', res)
+
+    @classmethod
+    def set_log_file (cls, log_file):
+        """redirect logger from stderr to file, can be called any time"""
+        try:
+            file = log_file.encode ()
+        except:
+            file = log_file
+        res = BoardControllerDLL.get_instance ().set_log_file (file)
+        if res != StreamExitCodes.STATUS_OK.value:
+            raise BrainFlowError ('unable to redirect logs to a file', res)
 
     def prepare_session (self):
         """prepare streaming sesssion, init resources, you need to call it before any other BoardShim object methods"""

--- a/r-package/brainflow/R/board_shim.R
+++ b/r-package/brainflow/R/board_shim.R
@@ -80,3 +80,11 @@ get_board_data <- function(board_shim) {
 config_board <- function(board_shim, config) {
     board_shim$config_board(config)
 }
+
+#' @param board_shim
+#' @param log_file
+#'
+#' @export
+set_log_file <- function(board_shim, log_file) {
+    board_shim$set_log_file(log_file)
+}

--- a/src/board_controller/board.cpp
+++ b/src/board_controller/board.cpp
@@ -1,7 +1,9 @@
 #include "board.h"
 #include "board_controller.h"
 
-spdlog::logger *Board::board_logger = spdlog::stderr_logger_mt ("board_logger").get ();
+#define LOGGER_NAME "board_logger"
+
+std::shared_ptr<spdlog::logger> Board::board_logger = spdlog::stderr_logger_mt (LOGGER_NAME);
 
 int Board::set_log_level (int level)
 {
@@ -12,6 +14,16 @@ int Board::set_log_level (int level)
         log_level = 0;
     Board::board_logger->set_level (spdlog::level::level_enum (log_level));
     Board::board_logger->flush_on (spdlog::level::level_enum (log_level));
+    return STATUS_OK;
+}
+
+int Board::set_log_file (char *log_file)
+{
+    spdlog::level::level_enum level = Board::board_logger->level ();
+    spdlog::drop (LOGGER_NAME);
+    Board::board_logger = spdlog::basic_logger_mt (LOGGER_NAME, log_file);
+    Board::board_logger->set_level (level);
+    Board::board_logger->flush_on (level);
     return STATUS_OK;
 }
 

--- a/src/board_controller/board_controller.cpp
+++ b/src/board_controller/board_controller.cpp
@@ -168,6 +168,12 @@ int set_log_level (int log_level)
     return Board::set_log_level (log_level);
 }
 
+int set_log_file (char *log_file)
+{
+    std::lock_guard<std::mutex> lock (mutex);
+    return Board::set_log_file (log_file);
+}
+
 int config_board (char *config, int board_id, char *port_name)
 {
     std::lock_guard<std::mutex> lock (mutex);

--- a/src/board_controller/inc/board.h
+++ b/src/board_controller/inc/board.h
@@ -9,8 +9,9 @@
 class Board
 {
 public:
-    static spdlog::logger *board_logger;
+    static std::shared_ptr<spdlog::logger> board_logger;
     static int set_log_level (int level);
+    static int set_log_file (char *log_file);
 
     virtual ~Board ()
     {

--- a/src/board_controller/inc/board_controller.h
+++ b/src/board_controller/inc/board_controller.h
@@ -53,6 +53,7 @@ extern "C"
         int data_count, float *data_buf, double *ts_buf, int board_id, char *port_name);
     SHARED_EXPORT int set_log_level (int log_level);
     SHARED_EXPORT int config_board (char *config, int board_id, char *port_name);
+    SHARED_EXPORT int set_log_file (char *log_file);
 #ifdef __cplusplus
 }
 #endif

--- a/tests/cpp/src/brainflow_get_data.cpp
+++ b/tests/cpp/src/brainflow_get_data.cpp
@@ -38,7 +38,6 @@ int main (int argc, char *argv[])
     }
 
     BoardShim::enable_board_logger ();
-    BoardShim::set_log_file ("test_log.txt");
 
     int board_id = atoi (argv[1]);
     BoardShim *board = new BoardShim (board_id, argv[2]);

--- a/tests/cpp/src/brainflow_get_data.cpp
+++ b/tests/cpp/src/brainflow_get_data.cpp
@@ -8,7 +8,6 @@
 #include <unistd.h>
 #endif
 
-#include "board_controller.h"
 #include "board_shim.h"
 #include "data_handler.h"
 
@@ -38,7 +37,8 @@ int main (int argc, char *argv[])
         return -1;
     }
 
-    set_log_level (2);
+    BoardShim::enable_board_logger ();
+    BoardShim::set_log_file ("test_log.txt");
 
     int board_id = atoi (argv[1]);
     BoardShim *board = new BoardShim (board_id, argv[2]);

--- a/tests/java/BrainFlowTest.java
+++ b/tests/java/BrainFlowTest.java
@@ -4,8 +4,8 @@ public class BrainFlowTest {
 
     public static void main (String[] args) throws Exception {
 
-        BoardShim.enable_board_logger();
-        BoardShim.set_log_file("test_log.txt");
+        BoardShim.enable_board_logger ();
+        BoardShim.set_log_file ("test_log.txt");
         BoardShim board_shim = new BoardShim (Integer.parseInt (args[0]), args[1]);
         board_shim.prepare_session ();
         System.out.println ("Session is ready");

--- a/tests/java/BrainFlowTest.java
+++ b/tests/java/BrainFlowTest.java
@@ -5,7 +5,6 @@ public class BrainFlowTest {
     public static void main (String[] args) throws Exception {
 
         BoardShim.enable_board_logger ();
-        BoardShim.set_log_file ("test_log.txt");
         BoardShim board_shim = new BoardShim (Integer.parseInt (args[0]), args[1]);
         board_shim.prepare_session ();
         System.out.println ("Session is ready");

--- a/tests/java/BrainFlowTest.java
+++ b/tests/java/BrainFlowTest.java
@@ -4,7 +4,9 @@ public class BrainFlowTest {
 
     public static void main (String[] args) throws Exception {
 
-        BoardShim board_shim = new BoardShim (Integer.parseInt (args[0]), args[1], true);
+        BoardShim.enable_board_logger();
+        BoardShim.set_log_file("test_log.txt");
+        BoardShim board_shim = new BoardShim (Integer.parseInt (args[0]), args[1]);
         board_shim.prepare_session ();
         System.out.println ("Session is ready");
         board_shim.start_stream (3600);

--- a/tests/python/brainflow_get_data.py
+++ b/tests/python/brainflow_get_data.py
@@ -24,7 +24,7 @@ def main ():
     # different board have different data formats
     if args.board != brainflow.GANGLION.board_id:
         board.config_board ('x2100000X')
-    else args.board == brainflow.GANGLION.board_id:
+    else:
         board.config_board ('2')
 
     board.start_stream ()

--- a/tests/python/brainflow_get_data.py
+++ b/tests/python/brainflow_get_data.py
@@ -10,8 +10,6 @@ def main ():
     parser.add_argument ('--log', action = 'store_true')
     args = parser.parse_args ()
 
-    brainflow.board_shim.BoardShim.set_log_file ('test_log.txt')
-
     if (args.log):
         brainflow.board_shim.BoardShim.enable_dev_board_logger ()
     else:

--- a/tests/python/brainflow_get_data.py
+++ b/tests/python/brainflow_get_data.py
@@ -10,6 +10,8 @@ def main ():
     parser.add_argument ('--log', action = 'store_true')
     args = parser.parse_args ()
 
+    brainflow.board_shim.BoardShim.set_log_file ('test_log.txt')
+
     if (args.log):
         brainflow.board_shim.BoardShim.enable_dev_board_logger ()
     else:
@@ -20,12 +22,10 @@ def main ():
     
     # disable second channel, note emulator doesnt handle such commands, run with real board to validate
     # different board have different data formats
-    if args.board in (brainflow.CYTON.board_id, brainflow.CYTON_DAISY.board_id, brainflow.SYNTHETIC.board_id, brainflow.NOVAXR.board_id):
+    if args.board != brainflow.GANGLION.board_id:
         board.config_board ('x2100000X')
-    elif args.board == brainflow.GANGLION.board_id:
+    else args.board == brainflow.GANGLION.board_id:
         board.config_board ('2')
-    else:
-        print ('unexpected board id')
 
     board.start_stream ()
     time.sleep (10)


### PR DESCRIPTION
add set_log_file method for apps wo stderr, uniform logging methods accross all bindings

@daniellasry important changes in java binding - some variables are private now, logging methods are static and in constructor there is no third arg now because I've moved dyn lib loading code to static initializer(it's the easiest option to add static log methods)

Also it fixes broken travis in master branch(new cmake version in pypi fails to install)

Signed-off-by: Andrey Parfenov <a1994ndrey@gmail.com>