### PR TITLE
read multiple packages for wifi shield

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,6 +96,12 @@ script:
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then
       sudo -H python3 $TRAVIS_BUILD_DIR/emulator/brainflow_emulator/wifi_shield_emulator.py python3 $TRAVIS_BUILD_DIR/tests/python/brainflow_get_data.py --log --board-id 4 --ip-address 127.0.0.1 --ip-protocol 2 --ip-port 17982 ;
     fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then
+      sudo -H python3 $TRAVIS_BUILD_DIR/emulator/brainflow_emulator/wifi_shield_emulator.py python3 $TRAVIS_BUILD_DIR/tests/python/brainflow_get_data.py --log --board-id 5 --ip-address 127.0.0.1 --ip-protocol 2 --ip-port 17983 ;
+    fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then
+      sudo -H python3 $TRAVIS_BUILD_DIR/emulator/brainflow_emulator/wifi_shield_emulator.py python3 $TRAVIS_BUILD_DIR/tests/python/brainflow_get_data.py --log --board-id 6 --ip-address 127.0.0.1 --ip-protocol 2 --ip-port 17984 ;
+    fi
 
 after_success:
   - sudo -H pip3 install awscli

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -67,8 +67,8 @@ test_script:
   - python %APPVEYOR_BUILD_FOLDER%\emulator\brainflow_emulator\novaxr_tcp.py %APPVEYOR_BUILD_FOLDER%\csharp-package\brainflow\test\bin\Release\test.exe --board-id 3 --ip-address 127.0.0.1 --ip-protocol 2
   # tests for wifi shield based boards
   - python %APPVEYOR_BUILD_FOLDER%\emulator\brainflow_emulator\wifi_shield_emulator.py python %APPVEYOR_BUILD_FOLDER%\tests\python\brainflow_get_data.py --board-id 4 --ip-address 127.0.0.1 --ip-protocol 2 --ip-port 17982
-  - python %APPVEYOR_BUILD_FOLDER%\emulator\brainflow_emulator\wifi_shield_emulator.py %APPVEYOR_BUILD_FOLDER%\tests\cpp\build\Release\test_get_data.exe --board-id 5 --ip-address 127.0.0.1 --ip-protocol 2 --ip-port 17982
-  - python %APPVEYOR_BUILD_FOLDER%\emulator\brainflow_emulator\wifi_shield_emulator.py %APPVEYOR_BUILD_FOLDER%\csharp-package\brainflow\test\bin\Release\test.exe --board-id 6 --ip-address 127.0.0.1 --ip-protocol 2 --ip-port 17982
+  - python %APPVEYOR_BUILD_FOLDER%\emulator\brainflow_emulator\wifi_shield_emulator.py %APPVEYOR_BUILD_FOLDER%\tests\cpp\build\Release\test_get_data.exe --board-id 5 --ip-address 127.0.0.1 --ip-protocol 2 --ip-port 17983
+  - python %APPVEYOR_BUILD_FOLDER%\emulator\brainflow_emulator\wifi_shield_emulator.py %APPVEYOR_BUILD_FOLDER%\csharp-package\brainflow\test\bin\Release\test.exe --board-id 6 --ip-address 127.0.0.1 --ip-protocol 2 --ip-port 17984
 
 deploy_script:
   - python -m pip install wheel > wheel_install.txt

--- a/emulator/brainflow_emulator/wifi_shield_emulator.py
+++ b/emulator/brainflow_emulator/wifi_shield_emulator.py
@@ -24,17 +24,17 @@ class ShieldWriter (threading.Thread):
 
     def run (self):
         while self.need_data:
-            if self.package_num % 256 == 0:
-                self.package_num = 0
-
             package = list ()
-            package.append (0xA0)
-            package.append (self.package_num)
-            for i in range (2, self.package_size - 1):
-                package.append (randint (0, 255))
-            package.append (0xC0)
+            for _ in range (6):
+                package.append (0xA0)
+                package.append (self.package_num)
+                for i in range (2, self.package_size - 1):
+                    package.append (randint (0, 255))
+                package.append (0xC0)
+                self.package_num = self.package_num + 1
+                if self.package_num % 256 == 0:
+                    self.package_num = 0
             self.write_socket.sendall (bytes (package))
-            self.package_num = self.package_num + 1
             time.sleep (self.delay)
 
 

--- a/src/board_controller/openbci/cyton_wifi.cpp
+++ b/src/board_controller/openbci/cyton_wifi.cpp
@@ -2,6 +2,7 @@
 #include "custom_cast.h"
 #include "timestamp.h"
 
+
 #define START_BYTE 0xA0
 #define END_BYTE_STANDARD 0xC0
 #define END_BYTE_ANALOG 0xC1
@@ -25,67 +26,66 @@ void CytonWifi::read_thread ()
         Byte 33: 0xCX where X is 0-F in hex
     */
     int res;
-    unsigned char b[32];
+    unsigned char b[OpenBCIWifiShieldBoard::transaction_size];
     while (keep_alive)
     {
         // check start byte
-        res = server_socket->recv (b, 1);
-        if (res != 1)
+        res = server_socket->recv (b, OpenBCIWifiShieldBoard::transaction_size);
+        if (res != OpenBCIWifiShieldBoard::transaction_size)
         {
             continue;
         }
-        if (b[0] != START_BYTE)
+        for (int cur_package = 0;
+             cur_package < OpenBCIWifiShieldBoard::num_packages_per_transaction; cur_package++)
         {
-            continue;
-        }
+            int offset = cur_package * OpenBCIWifiShieldBoard::package_size;
+            if (b[0 + offset] != START_BYTE)
+            {
+                continue;
+            }
 
-        res = server_socket->recv (b, 32);
-        if (res != 32)
-        {
-            continue;
-        }
+            double package[22] = {0.};
+            // package num
+            package[0] = (double)b[1 + offset];
+            // eeg
+            for (int i = 0; i < 8; i++)
+            {
+                package[i + 1] = eeg_scale * cast_24bit_to_int32 (b + 2 + 3 * i + offset);
+            }
+            // end byte
+            package[12] = (double)b[32 + offset];
+            // check end byte
+            if (b[32 + offset] == END_BYTE_STANDARD)
+            {
+                // accel
+                package[9] = accel_scale * cast_16bit_to_int32 (b + 26 + offset);
+                package[10] = accel_scale * cast_16bit_to_int32 (b + 28 + offset);
+                package[11] = accel_scale * cast_16bit_to_int32 (b + 30 + offset);
+            }
+            else if (b[32 + offset] == END_BYTE_ANALOG)
+            {
+                // analog
+                package[19] = cast_16bit_to_int32 (b + 26 + offset);
+                package[20] = cast_16bit_to_int32 (b + 28 + offset);
+                package[21] = cast_16bit_to_int32 (b + 30 + offset);
+            }
+            else if ((b[32 + offset] > END_BYTE_ANALOG) && (b[32 + offset] <= END_BYTE_MAX))
+            {
+                // unprocessed bytes
+                package[13] = (double)b[26 + offset];
+                package[14] = (double)b[27 + offset];
+                package[15] = (double)b[28 + offset];
+                package[16] = (double)b[29 + offset];
+                package[17] = (double)b[30 + offset];
+                package[18] = (double)b[31 + offset];
+            }
+            else
+            {
+                safe_logger (spdlog::level::warn, "Wrong end byte, found {}", b[32 + offset]);
+                continue;
+            }
 
-        double package[22] = {0.};
-        // package num
-        package[0] = (double)b[0];
-        // eeg
-        for (int i = 0; i < 8; i++)
-        {
-            package[i + 1] = eeg_scale * cast_24bit_to_int32 (b + 1 + 3 * i);
+            db->add_data (get_timestamp (), package);
         }
-        // end byte
-        package[12] = (double)b[res - 1];
-        // check end byte
-        if (b[res - 1] == END_BYTE_STANDARD)
-        {
-            // accel
-            package[9] = accel_scale * cast_16bit_to_int32 (b + 25);
-            package[10] = accel_scale * cast_16bit_to_int32 (b + 27);
-            package[11] = accel_scale * cast_16bit_to_int32 (b + 29);
-        }
-        else if (b[res - 1] == END_BYTE_ANALOG)
-        {
-            // analog
-            package[19] = cast_16bit_to_int32 (b + 25);
-            package[20] = cast_16bit_to_int32 (b + 27);
-            package[21] = cast_16bit_to_int32 (b + 29);
-        }
-        else if ((b[res - 1] > END_BYTE_ANALOG) && (b[res - 1] <= END_BYTE_MAX))
-        {
-            // unprocessed bytes
-            package[13] = (double)b[25];
-            package[14] = (double)b[26];
-            package[15] = (double)b[27];
-            package[16] = (double)b[28];
-            package[17] = (double)b[29];
-            package[18] = (double)b[30];
-        }
-        else
-        {
-            safe_logger (spdlog::level::warn, "Wrong end byte, found {}", b[res - 1]);
-            continue;
-        }
-
-        db->add_data (get_timestamp (), package);
     }
 }

--- a/src/board_controller/openbci/ganglion_wifi.cpp
+++ b/src/board_controller/openbci/ganglion_wifi.cpp
@@ -2,6 +2,7 @@
 #include "custom_cast.h"
 #include "timestamp.h"
 
+
 #define START_BYTE 0xA0
 #define END_BYTE_STANDARD 0xC0
 #define END_BYTE_ANALOG 0xC1
@@ -22,68 +23,67 @@ void GanglionWifi::read_thread ()
         Byte 33: 0xCX where X is 0-F in hex
     */
     int res;
-    unsigned char b[32];
+    unsigned char b[OpenBCIWifiShieldBoard::transaction_size];
     while (keep_alive)
     {
         // check start byte
-        res = server_socket->recv (b, 1);
-        if (res != 1)
+        res = server_socket->recv (b, OpenBCIWifiShieldBoard::transaction_size);
+        if (res != OpenBCIWifiShieldBoard::transaction_size)
         {
             continue;
         }
-        if (b[0] != START_BYTE)
+        for (int cur_package = 0;
+             cur_package < OpenBCIWifiShieldBoard::num_packages_per_transaction; cur_package++)
         {
-            continue;
-        }
+            int offset = cur_package * OpenBCIWifiShieldBoard::package_size;
+            if (b[0 + offset] != START_BYTE)
+            {
+                continue;
+            }
 
-        res = server_socket->recv (b, 32);
-        if (res != 32)
-        {
-            continue;
-        }
+            double package[18] = {0.};
+            // package num
+            package[0] = (double)b[1 + offset];
+            // eeg
+            for (int i = 0; i < 4; i++)
+            {
+                package[i + 1] = eeg_scale * cast_24bit_to_int32 (b + 2 + 3 * i + offset);
+            }
+            // end byte
+            package[8] = (double)b[32 + offset];
+            // check end byte
+            if (b[32 + offset] == END_BYTE_STANDARD)
+            {
+                // accel
+                package[5] = accel_scale * cast_16bit_to_int32 (b + 26 + offset);
+                package[6] = accel_scale * cast_16bit_to_int32 (b + 28 + offset);
+                package[7] = accel_scale * cast_16bit_to_int32 (b + 30 + offset);
+            }
+            else if (b[32 + offset] == END_BYTE_ANALOG)
+            {
+                // analog
+                package[15] = cast_16bit_to_int32 (b + 26 + offset);
+                package[16] = cast_16bit_to_int32 (b + 28 + offset);
+                package[17] = cast_16bit_to_int32 (b + 30 + offset);
+            }
+            else if ((b[32 + offset] > END_BYTE_ANALOG) && (b[32 + offset] <= END_BYTE_MAX))
+            {
+                // other data
+                package[8] = (double)b[32 + offset];
+                package[9] = (double)b[26 + offset];
+                package[10] = (double)b[27 + offset];
+                package[11] = (double)b[28 + offset];
+                package[12] = (double)b[29 + offset];
+                package[13] = (double)b[30 + offset];
+                package[14] = (double)b[31 + offset];
+            }
+            else
+            {
+                safe_logger (spdlog::level::warn, "Wrong end byte, found {}", b[32 + offset]);
+                continue;
+            }
 
-        double package[18] = {0.};
-        // package num
-        package[0] = (double)b[0];
-        // eeg
-        for (int i = 0; i < 4; i++)
-        {
-            package[i + 1] = eeg_scale * cast_24bit_to_int32 (b + 1 + 3 * i);
+            db->add_data (get_timestamp (), package);
         }
-        // end byte
-        package[8] = (double)b[res - 1];
-        // check end byte
-        if (b[res - 1] == END_BYTE_STANDARD)
-        {
-            // accel
-            package[5] = accel_scale * cast_16bit_to_int32 (b + 25);
-            package[6] = accel_scale * cast_16bit_to_int32 (b + 27);
-            package[7] = accel_scale * cast_16bit_to_int32 (b + 29);
-        }
-        else if (b[res - 1] == END_BYTE_ANALOG)
-        {
-            // analog
-            package[15] = cast_16bit_to_int32 (b + 25);
-            package[16] = cast_16bit_to_int32 (b + 27);
-            package[17] = cast_16bit_to_int32 (b + 29);
-        }
-        else if ((b[res - 1] > END_BYTE_ANALOG) && (b[res - 1] <= END_BYTE_MAX))
-        {
-            // other data
-            package[8] = (double)b[res - 1];
-            package[9] = (double)b[25];
-            package[10] = (double)b[26];
-            package[11] = (double)b[27];
-            package[12] = (double)b[28];
-            package[13] = (double)b[29];
-            package[14] = (double)b[30];
-        }
-        else
-        {
-            safe_logger (spdlog::level::warn, "Wrong end byte, found {}", b[res - 1]);
-            continue;
-        }
-
-        db->add_data (get_timestamp (), package);
     }
 }

--- a/src/board_controller/openbci/inc/openbci_wifi_shield_board.h
+++ b/src/board_controller/openbci/inc/openbci_wifi_shield_board.h
@@ -35,4 +35,9 @@ public:
     int stop_stream ();
     int release_session ();
     int config_board (char *config);
+
+    static constexpr int package_size = 33;
+    static constexpr int num_packages_per_transaction =
+        6; // should be even for correct parsing in daisy
+    static constexpr int transaction_size = package_size * num_packages_per_transaction;
 };

--- a/src/board_controller/openbci/openbci_wifi_shield_board.cpp
+++ b/src/board_controller/openbci/openbci_wifi_shield_board.cpp
@@ -63,7 +63,8 @@ int OpenBCIWifiShieldBoard::prepare_session ()
     safe_logger (spdlog::level::info, "local ip addr is {}", local_ip);
 
     server_socket = new SocketServer (local_ip, params.ip_port);
-    res = server_socket->bind ();
+    res = server_socket->bind (
+        OpenBCIWifiShieldBoard::transaction_size); // set min bytes returned by recv
     if (res != 0)
     {
         safe_logger (spdlog::level::err, "failed to create server socket with addr {} and port {}",

--- a/src/utils/socket_client.cpp
+++ b/src/utils/socket_client.cpp
@@ -91,7 +91,7 @@ SocketClient::SocketClient (const char *ip_addr, int port, int socket_type)
     this->socket_type = socket_type;
 }
 
-int SocketClient::connect ()
+int SocketClient::connect (int min_bytes)
 {
     WSADATA wsadata;
     int res = WSAStartup (MAKEWORD (2, 2), &wsadata);
@@ -132,6 +132,9 @@ int SocketClient::connect ()
         {
             return (int)SocketReturnCodes::CONNECT_ERROR;
         }
+        // to simplify parsing code and make it uniform for udp and tcp set min bytes for tcp to
+        // package size
+        setsockopt (connect_socket, SOL_SOCKET, SO_RCVLOWAT, &min_bytes, sizeof (min_bytes));
     }
 
     return (int)SocketReturnCodes::STATUS_OK;
@@ -262,7 +265,7 @@ SocketClient::SocketClient (const char *ip_addr, int port, int socket_type)
     this->socket_type = socket_type;
 }
 
-int SocketClient::connect ()
+int SocketClient::connect (int min_bytes)
 {
     if (socket_type == (int)SocketType::UDP)
     {
@@ -300,6 +303,9 @@ int SocketClient::connect ()
         {
             return (int)SocketReturnCodes::CONNECT_ERROR;
         }
+        // to simplify parsing code and make it uniform for udp and tcp set min bytes for tcp to
+        // package size
+        setsockopt (connect_socket, SOL_SOCKET, SO_RCVLOWAT, &min_bytes, sizeof (min_bytes));
     }
 
     return (int)SocketReturnCodes::STATUS_OK;

--- a/src/utils/socket_client.cpp
+++ b/src/utils/socket_client.cpp
@@ -134,7 +134,8 @@ int SocketClient::connect (int min_bytes)
         }
         // to simplify parsing code and make it uniform for udp and tcp set min bytes for tcp to
         // package size
-        setsockopt (connect_socket, SOL_SOCKET, SO_RCVLOWAT, &min_bytes, sizeof (min_bytes));
+        setsockopt (
+            connect_socket, SOL_SOCKET, SO_RCVLOWAT, (char *)&min_bytes, sizeof (min_bytes));
     }
 
     return (int)SocketReturnCodes::STATUS_OK;

--- a/src/utils/socket_client.h
+++ b/src/utils/socket_client.h
@@ -39,7 +39,7 @@ public:
         close ();
     }
 
-    int connect ();
+    int connect (int min_bytes = 1); // makes sense only for tcp
     int send (const char *data, int size);
     int recv (void *data, int size);
     void close ();

--- a/src/utils/socket_server.cpp
+++ b/src/utils/socket_server.cpp
@@ -19,7 +19,7 @@ SocketServer::SocketServer (const char *local_ip, int local_port)
     client_connected = false;
 }
 
-int SocketServer::bind ()
+int SocketServer::bind (int min_bytes)
 {
     WSADATA wsadata;
     int res = WSAStartup (MAKEWORD (2, 2), &wsadata);
@@ -50,6 +50,14 @@ int SocketServer::bind ()
     setsockopt (server_socket, IPPROTO_TCP, TCP_NODELAY, (char *)&value, sizeof (value));
     setsockopt (server_socket, SOL_SOCKET, SO_RCVTIMEO, (char *)&timeout, sizeof (timeout));
     setsockopt (server_socket, SOL_SOCKET, SO_SNDTIMEO, (char *)&timeout, sizeof (timeout));
+    // set linger timeout to 1s to handle time_wait state gracefully
+    struct linger sl;
+    sl.l_onoff = 1;
+    sl.l_linger = 1;
+    setsockopt (server_socket, SOL_SOCKET, SO_LINGER, &sl, sizeof (sl));
+    // to simplify parsing code and make it uniform for udp and tcp set min bytes for tcp to
+    // package size
+    setsockopt (server_socket, SOL_SOCKET, SO_RCVLOWAT, &min_bytes, sizeof (min_bytes));
 
     if ((listen (server_socket, 1)) != 0)
     {
@@ -133,7 +141,7 @@ SocketServer::SocketServer (const char *local_ip, int local_port)
     client_connected = false;
 }
 
-int SocketServer::bind ()
+int SocketServer::bind (int min_bytes)
 {
     server_socket = socket (AF_INET, SOCK_STREAM, IPPROTO_TCP);
     if (server_socket < 0)
@@ -160,6 +168,14 @@ int SocketServer::bind ()
     setsockopt (server_socket, IPPROTO_TCP, TCP_NODELAY, &value, sizeof (value));
     setsockopt (server_socket, SOL_SOCKET, SO_RCVTIMEO, (const char *)&tv, sizeof (tv));
     setsockopt (server_socket, SOL_SOCKET, SO_SNDTIMEO, (const char *)&tv, sizeof (tv));
+    // set linger timeout to 1s to handle time_wait state gracefully
+    struct linger sl;
+    sl.l_onoff = 1;
+    sl.l_linger = 1;
+    setsockopt (server_socket, SOL_SOCKET, SO_LINGER, &sl, sizeof (sl));
+    // to simplify parsing code and make it uniform for udp and tcp set min bytes for tcp to
+    // package size
+    setsockopt (server_socket, SOL_SOCKET, SO_RCVLOWAT, &min_bytes, sizeof (min_bytes));
 
     if ((listen (server_socket, 1)) != 0)
     {

--- a/src/utils/socket_server.cpp
+++ b/src/utils/socket_server.cpp
@@ -54,10 +54,10 @@ int SocketServer::bind (int min_bytes)
     struct linger sl;
     sl.l_onoff = 1;
     sl.l_linger = 1;
-    setsockopt (server_socket, SOL_SOCKET, SO_LINGER, &sl, sizeof (sl));
+    setsockopt (server_socket, SOL_SOCKET, SO_LINGER, (char *)&sl, sizeof (sl));
     // to simplify parsing code and make it uniform for udp and tcp set min bytes for tcp to
     // package size
-    setsockopt (server_socket, SOL_SOCKET, SO_RCVLOWAT, &min_bytes, sizeof (min_bytes));
+    setsockopt (server_socket, SOL_SOCKET, SO_RCVLOWAT, (char *)&min_bytes, sizeof (min_bytes));
 
     if ((listen (server_socket, 1)) != 0)
     {

--- a/src/utils/socket_server.h
+++ b/src/utils/socket_server.h
@@ -15,7 +15,7 @@ public:
         close ();
     }
 
-    int bind ();
+    int bind (int min_bytes = 1);
     int accept ();
     int recv (void *data, int size);
     void close ();


### PR DESCRIPTION
Signed-off-by: Andrey Parfenov <a1994ndrey@gmail.com>

right now there is a potential issue in parsing for wifi shield, if we read less bytes than we request we just drop them but for tcp its not acceptable because it will break all parsing.

Changes to fix it:

* add SO_RCVLOWAT and set it to package size, now we should read exactly the same amount of bytes
* handle time_wait state gracefully using linger option
* read multiple packages per one transaction( I am not sure that its required and I dont like it, but I 've decided to leverage code from novaxr)