### PR TITLE
add streaming board

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -121,10 +121,12 @@ script:
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then
       sudo -H python3 $TRAVIS_BUILD_DIR/emulator/brainflow_emulator/wifi_shield_emulator.py python3 $TRAVIS_BUILD_DIR/tests/python/brainflow_get_data.py --log --board-id 6 --ip-address 127.0.0.1 --ip-port 17984 ;
     fi
-  # todo replace it by error suppression in http.h file, there is nothing critical in terms of errors
-  # - if [ `which valgrind` ]; then
-  #    sudo -H LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$TRAVIS_BUILD_DIR/installed/lib python3 $TRAVIS_BUILD_DIR/emulator/brainflow_emulator/wifi_shield_emulator.py valgrind --error-exitcode=1 --leak-check=full $TRAVIS_BUILD_DIR/tests/cpp/get_data_demo/build/brainflow_get_data --board-id 6 --ip-address 127.0.0.1 --ip-port 17985 ;
-  #  fi
+  # tests for streaming board
+  - python $TRAVIS_BUILD_DIR/emulator/brainflow_emulator/streaming_board_emulator.py python $TRAVIS_BUILD_DIR/tests/python/brainflow_get_data.py --log --board-id -2 --ip-address 225.1.1.1 --ip-port 6677 --other-info -1
+  - if [ `which valgrind` ]; then
+      python $TRAVIS_BUILD_DIR/emulator/brainflow_emulator/streaming_board_emulator.py valgrind --error-exitcode=1 --leak-check=full $TRAVIS_BUILD_DIR/tests/cpp/get_data_demo/build/brainflow_get_data --board-id -2 --ip-address 225.1.1.1 --ip-port 6677 --other-info -1 ;
+    fi
+
   # tests for signal processing
   # python
   - python3 $TRAVIS_BUILD_DIR/tests/python/denoising.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -123,7 +123,7 @@ script:
     fi
   # tests for streaming board
   - python3 $TRAVIS_BUILD_DIR/emulator/brainflow_emulator/streaming_board_emulator.py python3 $TRAVIS_BUILD_DIR/tests/python/brainflow_get_data.py --log --board-id -2 --ip-address 225.1.1.1 --ip-port 6677 --other-info -1
-  - $TRAVIS_BUILD_DIR/emulator/brainflow_emulator/streaming_board_emulator.py $TRAVIS_BUILD_DIR/tests/cpp/get_data_demo/build/brainflow_get_data --board-id -2 --ip-address 225.1.1.1 --ip-port 6677 --other-info -1
+  - python3 $TRAVIS_BUILD_DIR/emulator/brainflow_emulator/streaming_board_emulator.py $TRAVIS_BUILD_DIR/tests/cpp/get_data_demo/build/brainflow_get_data --board-id -2 --ip-address 225.1.1.1 --ip-port 6677 --other-info -1
   # there is an error in valgrind but this error doesnt make any sense and looks like smth outside our control
   # - if [ `which valgrind` ]; then
   #    python3 $TRAVIS_BUILD_DIR/emulator/brainflow_emulator/streaming_board_emulator.py valgrind --error-exitcode=1 --leak-check=full $TRAVIS_BUILD_DIR/tests/cpp/get_data_demo/build/brainflow_get_data --board-id -2 --ip-address 225.1.1.1 --ip-port 6677 --other-info -1 ;

--- a/.travis.yml
+++ b/.travis.yml
@@ -123,9 +123,10 @@ script:
     fi
   # tests for streaming board
   - python3 $TRAVIS_BUILD_DIR/emulator/brainflow_emulator/streaming_board_emulator.py python3 $TRAVIS_BUILD_DIR/tests/python/brainflow_get_data.py --log --board-id -2 --ip-address 225.1.1.1 --ip-port 6677 --other-info -1
-  - if [ `which valgrind` ]; then
-      python3 $TRAVIS_BUILD_DIR/emulator/brainflow_emulator/streaming_board_emulator.py valgrind --error-exitcode=1 --leak-check=full $TRAVIS_BUILD_DIR/tests/cpp/get_data_demo/build/brainflow_get_data --board-id -2 --ip-address 225.1.1.1 --ip-port 6677 --other-info -1 ;
-    fi
+  # there is an error in valgrind but this error doesnt make any sense and looks like smth outside our control
+  # - if [ `which valgrind` ]; then
+  #    python3 $TRAVIS_BUILD_DIR/emulator/brainflow_emulator/streaming_board_emulator.py valgrind --error-exitcode=1 --leak-check=full $TRAVIS_BUILD_DIR/tests/cpp/get_data_demo/build/brainflow_get_data --board-id -2 --ip-address 225.1.1.1 --ip-port 6677 --other-info -1 ;
+  #  fi
 
   # tests for signal processing
   # python

--- a/.travis.yml
+++ b/.travis.yml
@@ -123,6 +123,7 @@ script:
     fi
   # tests for streaming board
   - python3 $TRAVIS_BUILD_DIR/emulator/brainflow_emulator/streaming_board_emulator.py python3 $TRAVIS_BUILD_DIR/tests/python/brainflow_get_data.py --log --board-id -2 --ip-address 225.1.1.1 --ip-port 6677 --other-info -1
+  - $TRAVIS_BUILD_DIR/emulator/brainflow_emulator/streaming_board_emulator.py $TRAVIS_BUILD_DIR/tests/cpp/get_data_demo/build/brainflow_get_data --board-id -2 --ip-address 225.1.1.1 --ip-port 6677 --other-info -1
   # there is an error in valgrind but this error doesnt make any sense and looks like smth outside our control
   # - if [ `which valgrind` ]; then
   #    python3 $TRAVIS_BUILD_DIR/emulator/brainflow_emulator/streaming_board_emulator.py valgrind --error-exitcode=1 --leak-check=full $TRAVIS_BUILD_DIR/tests/cpp/get_data_demo/build/brainflow_get_data --board-id -2 --ip-address 225.1.1.1 --ip-port 6677 --other-info -1 ;

--- a/.travis.yml
+++ b/.travis.yml
@@ -124,10 +124,9 @@ script:
   # tests for streaming board
   - python3 $TRAVIS_BUILD_DIR/emulator/brainflow_emulator/streaming_board_emulator.py python3 $TRAVIS_BUILD_DIR/tests/python/brainflow_get_data.py --log --board-id -2 --ip-address 225.1.1.1 --ip-port 6677 --other-info -1
   - python3 $TRAVIS_BUILD_DIR/emulator/brainflow_emulator/streaming_board_emulator.py $TRAVIS_BUILD_DIR/tests/cpp/get_data_demo/build/brainflow_get_data --board-id -2 --ip-address 225.1.1.1 --ip-port 6677 --other-info -1
-  # there is an error in valgrind but this error doesnt make any sense and looks like smth outside our control
-  # - if [ `which valgrind` ]; then
-  #    python3 $TRAVIS_BUILD_DIR/emulator/brainflow_emulator/streaming_board_emulator.py valgrind --error-exitcode=1 --leak-check=full $TRAVIS_BUILD_DIR/tests/cpp/get_data_demo/build/brainflow_get_data --board-id -2 --ip-address 225.1.1.1 --ip-port 6677 --other-info -1 ;
-  #  fi
+  - if [ `which valgrind` ]; then
+      python3 $TRAVIS_BUILD_DIR/emulator/brainflow_emulator/streaming_board_emulator.py valgrind --error-exitcode=1 --leak-check=full $TRAVIS_BUILD_DIR/tests/cpp/get_data_demo/build/brainflow_get_data --board-id -2 --ip-address 225.1.1.1 --ip-port 6677 --other-info -1 ;
+    fi
 
   # tests for signal processing
   # python

--- a/.travis.yml
+++ b/.travis.yml
@@ -122,9 +122,9 @@ script:
       sudo -H python3 $TRAVIS_BUILD_DIR/emulator/brainflow_emulator/wifi_shield_emulator.py python3 $TRAVIS_BUILD_DIR/tests/python/brainflow_get_data.py --log --board-id 6 --ip-address 127.0.0.1 --ip-port 17984 ;
     fi
   # tests for streaming board
-  - python $TRAVIS_BUILD_DIR/emulator/brainflow_emulator/streaming_board_emulator.py python $TRAVIS_BUILD_DIR/tests/python/brainflow_get_data.py --log --board-id -2 --ip-address 225.1.1.1 --ip-port 6677 --other-info -1
+  - python3 $TRAVIS_BUILD_DIR/emulator/brainflow_emulator/streaming_board_emulator.py python3 $TRAVIS_BUILD_DIR/tests/python/brainflow_get_data.py --log --board-id -2 --ip-address 225.1.1.1 --ip-port 6677 --other-info -1
   - if [ `which valgrind` ]; then
-      python $TRAVIS_BUILD_DIR/emulator/brainflow_emulator/streaming_board_emulator.py valgrind --error-exitcode=1 --leak-check=full $TRAVIS_BUILD_DIR/tests/cpp/get_data_demo/build/brainflow_get_data --board-id -2 --ip-address 225.1.1.1 --ip-port 6677 --other-info -1 ;
+      python3 $TRAVIS_BUILD_DIR/emulator/brainflow_emulator/streaming_board_emulator.py valgrind --error-exitcode=1 --leak-check=full $TRAVIS_BUILD_DIR/tests/cpp/get_data_demo/build/brainflow_get_data --board-id -2 --ip-address 225.1.1.1 --ip-port 6677 --other-info -1 ;
     fi
 
   # tests for signal processing

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,6 +133,7 @@ set (BOARD_CONTROLLER_SRC
     ${CMAKE_HOME_DIRECTORY}/src/board_controller/board_controller.cpp
     ${CMAKE_HOME_DIRECTORY}/src/board_controller/board_info_getter.cpp
     ${CMAKE_HOME_DIRECTORY}/src/board_controller/board.cpp
+    ${CMAKE_HOME_DIRECTORY}/src/board_controller/streaming_board.cpp
     ${CMAKE_HOME_DIRECTORY}/src/board_controller/synthetic_board.cpp
     ${CMAKE_HOME_DIRECTORY}/src/board_controller/openbci/novaxr.cpp
     ${CMAKE_HOME_DIRECTORY}/src/board_controller/file_streamer.cpp

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -80,6 +80,8 @@ test_script:
   - python %APPVEYOR_BUILD_FOLDER%\emulator\brainflow_emulator\wifi_shield_emulator.py %APPVEYOR_BUILD_FOLDER%\tests\cpp\get_data_demo\build32\Release\brainflow_get_data.exe --board-id 5 --ip-address 127.0.0.1 --ip-port 17993
   - python %APPVEYOR_BUILD_FOLDER%\emulator\brainflow_emulator\wifi_shield_emulator.py %APPVEYOR_BUILD_FOLDER%\csharp-package\brainflow\brainflow_get_data\bin\Release\test.exe --board-id 6 --ip-address 127.0.0.1 --ip-port 17984  
   - python %APPVEYOR_BUILD_FOLDER%\emulator\brainflow_emulator\wifi_shield_emulator.py python %APPVEYOR_BUILD_FOLDER%\tests\python\brainflow_get_data.py --board-id 4 --ip-address 127.0.0.1 --ip-port 17986 --streamer-params file://file_streamer.csv:w
+  # tests for streaming board
+  - python %APPVEYOR_BUILD_FOLDER%\emulator\brainflow_emulator\streaming_board_emulator.py python %APPVEYOR_BUILD_FOLDER%\tests\python\brainflow_get_data.py --log --board-id -2 --ip-address 225.1.1.1 --ip-port 6677 --other-info -1
   # tests for signal processing
   # python
   - python %APPVEYOR_BUILD_FOLDER%\tests\python\denoising.py

--- a/cpp-package/src/inc/board_shim.h
+++ b/cpp-package/src/inc/board_shim.h
@@ -26,10 +26,15 @@ class BoardShim
 {
 
     void reshape_data (int data_points, double *linear_buffer, double **output_buf);
-    std::string input_params;
+    // can not init master_board_id in constructor cause we can not raise an exception from
+    // constructor, also can not do it only in prepare_session cause it might not be a first called
+    // method.
+    int get_master_board_id ();
+    std::string serialized_params;
+    struct BrainFlowInputParams params;
 
 public:
-    /// disable BrainFlow logger
+    /// disable BrainFlow loggers
     static void disable_board_logger ();
     /// enable BrainFlow logger with LEVEL_INFO
     static void enable_board_logger ();
@@ -85,7 +90,8 @@ public:
      * start streaming thread and store data in ringbuffer
      * @param buffer_size size of internal ring buffer
      * @param streamer_params use it to pass data packages further or store them directly during streaming,
-                    supported values: file://%file_name%:w, file://%file_name%:a, streaming_board://%multicast_group_ip%:%port%
+                    supported values: "file://%file_name%:w", "file://%file_name%:a", "streaming_board://%multicast_group_ip%:%port%"".
+                    Range for multicast addresses is from "224.0.0.0" to "239.255.255.255"
      */
     void start_stream (int buffer_size = 450000, char *streamer_params = NULL);
     // clang-format on

--- a/csharp-package/brainflow/brainflow/board_controller_library.cs
+++ b/csharp-package/brainflow/brainflow/board_controller_library.cs
@@ -40,6 +40,7 @@ namespace brainflow
 
     public enum BoardIds
     {
+        STREAMING_BOARD = -2,
         SYNTHETIC_BOARD = -1,
         CYTON_BOARD = 0,
         GANGLION_BOARD = 1,

--- a/docs/BrainFlowEmulator.rst
+++ b/docs/BrainFlowEmulator.rst
@@ -5,6 +5,22 @@ BrainFlow Emulator
 
 BrainFlow Emulator allows you to run all integration tests for all supported boards without real hardware, our CI uses it for test automation, also you can run it on your own PC.
 
+Streaming Board
+-----------------
+
+Streaming Board emulator works using Python binding for BrainFlow, so **you need to install Python binding first.**
+
+Install emulator package::
+
+    cd emulator
+    python -m pip install -U .
+
+Run tests ::
+
+    python emulator\brainflow_emulator\streaming_board_emulator.py python tests\python\brainflow_get_data.py --log --board-id -2 --ip-address 225.1.1.1 --ip-port 6677 --other-info -1
+
+This emulator uses synthetic board as a master board and ip address and port are hardcoded.
+
 OpenBCI Cyton
 --------------
 

--- a/docs/SupportedBoards.rst
+++ b/docs/SupportedBoards.rst
@@ -187,7 +187,7 @@ Board Spec:
 - num eeg(emg,...) channels: 4
 - num acceleration channels: 3
 - sampling rate: 1600
-- communication: TCP socket to read data and http to send commands
+- communication: TCP socket to read data and HTTP to send commands
 
 Cyton with Wifi Shield
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -218,7 +218,7 @@ Board Spec:
 - num eeg(emg,...) channels: 8
 - num acceleration channels: 3
 - sampling rate: 1000
-- communication: TCP socket to read data and http to send commands
+- communication: TCP socket to read data and HTTP to send commands
 
 Cyton Daisy with Wifi Shield
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -248,4 +248,4 @@ Board Spec:
 - num eeg(emg,...) channels: 16
 - num acceleration channels: 3
 - sampling rate: 1000
-- communication: TCP socket to read data and http to send commands
+- communication: TCP socket to read data and HTTP to send commands

--- a/docs/SupportedBoards.rst
+++ b/docs/SupportedBoards.rst
@@ -12,7 +12,7 @@ BrainFlow's boards can stream data to different destinations like file, socket a
 
 .. code-block:: python
 
-    # choose any supported multicast address(from "224.0.0.0" to "239.255.255.255") and port
+    # choose any valid multicast address(from "224.0.0.0" to "239.255.255.255") and port
     start_stream (450000, 'streaming_board://225.1.1.1:6677')
 
 **In the second process please specify:**
@@ -32,12 +32,12 @@ In methods like:
 
 .. code-block:: python
 
-   # these methods return an array of rows in this 2d array containing eeg\emg\ecg\accel data
    get_eeg_channels (board_id)
    get_emg_channels (board_id)
    get_ecg_channels (board_id)
+   # .......
 
-You need to write master board id instead Streaming Board Id, because exact data format for streaming board is controlled by master board as well as sampling rate.
+You need to use master board id instead Streaming Board Id, because exact data format for streaming board is controlled by master board as well as sampling rate.
 
 Board Specs:
 
@@ -187,7 +187,7 @@ Board Spec:
 - num eeg(emg,...) channels: 4
 - num acceleration channels: 3
 - sampling rate: 1600
-- communication: tcp socket to read data and http to send commands
+- communication: TCP socket to read data and http to send commands
 
 Cyton with Wifi Shield
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -218,7 +218,7 @@ Board Spec:
 - num eeg(emg,...) channels: 8
 - num acceleration channels: 3
 - sampling rate: 1000
-- communication: tcp socket to read data and http to send commands
+- communication: TCP socket to read data and http to send commands
 
 Cyton Daisy with Wifi Shield
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -248,4 +248,4 @@ Board Spec:
 - num eeg(emg,...) channels: 16
 - num acceleration channels: 3
 - sampling rate: 1000
-- communication: tcp socket to read data and http to send commands
+- communication: TCP socket to read data and http to send commands

--- a/docs/SupportedBoards.rst
+++ b/docs/SupportedBoards.rst
@@ -8,7 +8,7 @@ Streaming Board
 
 BrainFlow's boards can stream data to different destinations like file, socket and so on. This board acts like a consumer for data streamed from the main process.
 
-**To use it in first process you should call:**
+**To use it in the first process you should call:**
 
 .. code-block:: python
 

--- a/docs/SupportedBoards.rst
+++ b/docs/SupportedBoards.rst
@@ -3,6 +3,49 @@
 Supported Boards
 =================
 
+Streaming Board
+------------------
+
+BrainFlow's boards can stream data to different destinations like file, socket and so on. This board acts like a consumer for data streamed from the main process.
+
+**To use it in first process you should call:**
+
+.. code-block:: python
+
+    # choose any supported multicast address(from "224.0.0.0" to "239.255.255.255") and port
+    start_stream (450000, 'streaming_board://225.1.1.1:6677')
+
+**In the second process please specify:**
+
+- board_id: -2
+- ip_address field of BrainFlowInputParams structure, for example above it's 225.1.1.1
+- ip_port field of BrainFlowInputParams structure, for example above it's 6677
+- other_info field of BrainFlowInputParams structure, write there board_id for a board which acts like data provider(master board)
+
+Supported platforms:
+
+- Windows >= 8.1
+- Linux
+- MacOS
+
+In methods like:
+
+.. code-block:: python
+
+   # these methods return an array of rows in this 2d array containing eeg\emg\ecg\accel data
+   get_eeg_channels (board_id)
+   get_emg_channels (board_id)
+   get_ecg_channels (board_id)
+
+You need to write master board id instead Streaming Board Id, because exact data format for streaming board is controlled by master board as well as sampling rate.
+
+Board Specs:
+
+- num eeg(emg,...) channels: like in master board
+- num acceleration channels: like in master board
+- sampling rate: like in master board
+- communication: UDP multicast socket to read data from master board
+
 Synthetic Board
 ----------------
 

--- a/emulator/brainflow_emulator/streaming_board_emulator.py
+++ b/emulator/brainflow_emulator/streaming_board_emulator.py
@@ -1,0 +1,41 @@
+import logging
+import sys
+import time
+import subprocess
+
+import brainflow
+from brainflow.board_shim import BoardShim, BrainFlowInputParams, BoardIds
+from brainflow.data_filter import DataFilter, FilterTypes
+
+from brainflow_emulator.emulate_common import TestFailureError, log_multilines
+
+
+def run_test (cmd_list):
+    logging.info ('Running %s' % ' '.join ([str (x) for x in cmd_list]))
+    process = subprocess.Popen (cmd_list, stdout = subprocess.PIPE, stderr = subprocess.PIPE)
+    stdout, stderr = process.communicate ()
+
+    log_multilines (logging.info, stdout)
+    log_multilines (logging.info, stderr)
+
+    if process.returncode != 0:
+        raise TestFailureError ('Test failed with exit code %s' % str (process.returncode), process.returncode)
+
+    return stdout, stderr
+
+def main ():
+    BoardShim.enable_dev_board_logger ()
+    params = BrainFlowInputParams ()
+    board = BoardShim (BoardIds.SYNTHETIC_BOARD.value, params)
+    board.prepare_session ()
+    board.start_stream (450000, 'streaming_board://225.1.1.1:6677')
+
+    run_test (sys.argv[1:])
+
+    board.stop_stream ()
+    board.release_session ()
+
+
+if __name__ == "__main__":
+    logging.basicConfig (format = '%(asctime)s %(levelname)-8s %(message)s', level = logging.INFO)
+    main ()

--- a/java-package/brainflow/src/main/java/brainflow/BoardIds.java
+++ b/java-package/brainflow/src/main/java/brainflow/BoardIds.java
@@ -8,7 +8,7 @@ import java.util.Map;
  */
 public enum BoardIds
 {
-
+    STREAMING_BOARD (-2),
     SYNTHETIC_BOARD (-1),
     CYTON_BOARD (0),
     GANGLION_BOARD (1),

--- a/r-package/brainflow/R/board_shim.R
+++ b/r-package/brainflow/R/board_shim.R
@@ -1,6 +1,7 @@
 #' @export
 BoardIds <- function () {
     list (
+        STREAMING_BOARD = c (Id = as.integer (-2)),
         SYNTHETIC_BOARD = c (Id = as.integer (-1)),
         CYTON_BOARD = c (Id = as.integer (0)),
         GANGLION_BOARD = c (Id = as.integer (1)),

--- a/src/board_controller/board.cpp
+++ b/src/board_controller/board.cpp
@@ -79,7 +79,16 @@ int Board::prepare_streamer (char *streamer_params)
         }
         if (streamer_type == "streaming_board")
         {
-            int port = std::stoi (streamer_mods);
+            int port = 0;
+            try
+            {
+                port = std::stoi (streamer_mods);
+            }
+            catch (const std::exception &e)
+            {
+                safe_logger (spdlog::level::err, e.what ());
+                return INVALID_ARGUMENTS_ERROR;
+            }
             streamer = new MultiCastStreamer (streamer_dest.c_str (), port);
         }
 

--- a/src/board_controller/board_controller.cpp
+++ b/src/board_controller/board_controller.cpp
@@ -20,6 +20,7 @@
 #include "ganglion.h"
 #include "ganglion_wifi.h"
 #include "novaxr.h"
+#include "streaming_board.h"
 #include "synthetic_board.h"
 
 #include "json.hpp"
@@ -60,14 +61,17 @@ int prepare_session (int board_id, char *json_brainflow_input_params)
     std::shared_ptr<Board> board = NULL;
     switch (board_id)
     {
+        case STREAMING_BOARD:
+            board = std::shared_ptr<Board> (new StreamingBoard (params));
+            break;
+        case SYNTHETIC_BOARD:
+            board = std::shared_ptr<Board> (new SyntheticBoard (params));
+            break;
         case CYTON_BOARD:
             board = std::shared_ptr<Board> (new Cyton (params));
             break;
         case GANGLION_BOARD:
             board = std::shared_ptr<Board> (new Ganglion (params));
-            break;
-        case SYNTHETIC_BOARD:
-            board = std::shared_ptr<Board> (new SyntheticBoard (params));
             break;
         case CYTON_DAISY_BOARD:
             board = std::shared_ptr<Board> (new CytonDaisy (params));

--- a/src/board_controller/inc/brainflow_constants.h
+++ b/src/board_controller/inc/brainflow_constants.h
@@ -27,6 +27,7 @@ typedef enum
 
 typedef enum
 {
+    STREAMING_BOARD = -2,
     SYNTHETIC_BOARD = -1,
     CYTON_BOARD = 0,
     GANGLION_BOARD = 1,

--- a/src/board_controller/inc/streaming_board.h
+++ b/src/board_controller/inc/streaming_board.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <thread>
+
+#include "board.h"
+#include "board_controller.h"
+#include "multicast_client.h"
+
+
+class StreamingBoard : public Board
+{
+
+private:
+    volatile bool keep_alive;
+    bool initialized;
+    bool is_streaming;
+    std::thread streaming_thread;
+
+    MultiCastClient *client;
+
+    void read_thread ();
+
+public:
+    StreamingBoard (struct BrainFlowInputParams params);
+    ~StreamingBoard ();
+
+    int prepare_session ();
+    int start_stream (int buffer_size, char *streamer_params);
+    int stop_stream ();
+    int release_session ();
+    int config_board (char *config);
+};

--- a/src/board_controller/streaming_board.cpp
+++ b/src/board_controller/streaming_board.cpp
@@ -1,0 +1,192 @@
+#include <string.h>
+
+#include "board_info_getter.h"
+#include "streaming_board.h"
+
+#ifndef _WIN32
+#include <errno.h>
+#endif
+
+
+StreamingBoard::StreamingBoard (struct BrainFlowInputParams params)
+    : Board ((int)STREAMING_BOARD,
+          params) // its a hack - set board_id for streaming board here temporary and override it
+                  // with master board id in prepare_session, board_id is protected and there is no
+                  // api to get it so its ok
+{
+    client = NULL;
+    is_streaming = false;
+    keep_alive = false;
+    initialized = false;
+}
+
+StreamingBoard::~StreamingBoard ()
+{
+    skip_logs = true;
+    release_session ();
+}
+
+int StreamingBoard::prepare_session ()
+{
+    if (initialized)
+    {
+        safe_logger (spdlog::level::info, "Session is already prepared");
+        return STATUS_OK;
+    }
+    if ((params.ip_address.empty ()) || (params.other_info.empty ()) || (params.ip_port == 0))
+    {
+        safe_logger (spdlog::level::err,
+            "write multicast group ip to ip_address field, ip port to ip_port field and original "
+            "board id to other info");
+        return INVALID_ARGUMENTS_ERROR;
+    }
+    try
+    {
+        board_id = std::stoi (params.other_info);
+    }
+    catch (const std::exception &e)
+    {
+        safe_logger (spdlog::level::err,
+            "Write board id for the board which streams data to other_info field");
+        safe_logger (spdlog::level::err, e.what ());
+        return INVALID_ARGUMENTS_ERROR;
+    }
+
+    client = new MultiCastClient (params.ip_address.c_str (), params.ip_port);
+    int res = client->init ();
+    if (res != (int)MultiCastReturnCodes::STATUS_OK)
+    {
+#ifdef _WIN32
+        safe_logger (spdlog::level::err, "WSAGetLastError is {}", WSAGetLastError ());
+#else
+        safe_logger (spdlog::level::err, "errno {} message {}", errno, strerror (errno));
+#endif
+        safe_logger (spdlog::level::err, "failed to init socket: {}", res);
+        return GENERAL_ERROR;
+    }
+    initialized = true;
+    return STATUS_OK;
+}
+
+int StreamingBoard::config_board (char *config)
+{
+    // dont allow streaming boards to change config for master board
+    return UNSUPPORTED_BOARD_ERROR;
+}
+
+int StreamingBoard::start_stream (int buffer_size, char *streamer_params)
+{
+    if (is_streaming)
+    {
+        safe_logger (spdlog::level::err, "Streaming thread already running");
+        return STREAM_ALREADY_RUN_ERROR;
+    }
+    if (buffer_size <= 0 || buffer_size > MAX_CAPTURE_SAMPLES)
+    {
+        safe_logger (spdlog::level::err, "invalid array size");
+        return INVALID_BUFFER_SIZE_ERROR;
+    }
+
+    if (db)
+    {
+        delete db;
+        db = NULL;
+    }
+    if (streamer)
+    {
+        delete streamer;
+        streamer = NULL;
+    }
+
+    int res = prepare_streamer (streamer_params);
+    if (res != STATUS_OK)
+    {
+        return res;
+    }
+    int num_channels = 0;
+    res = get_num_rows (board_id, &num_channels);
+    if (res != STATUS_OK)
+    {
+        safe_logger (spdlog::level::err, "failed to get num rows for {}", board_id);
+        return res;
+    }
+    db = new DataBuffer (num_channels - 1, buffer_size); // -1 due to timestamps
+    if (!db->is_ready ())
+    {
+        safe_logger (spdlog::level::err, "unable to prepare buffer");
+        return INVALID_BUFFER_SIZE_ERROR;
+    }
+
+    keep_alive = true;
+    streaming_thread = std::thread ([this] { this->read_thread (); });
+    is_streaming = true;
+    return STATUS_OK;
+}
+
+int StreamingBoard::stop_stream ()
+{
+    if (is_streaming)
+    {
+        keep_alive = false;
+        is_streaming = false;
+        streaming_thread.join ();
+        if (streamer)
+        {
+            delete streamer;
+            streamer = NULL;
+        }
+        return STATUS_OK;
+    }
+    else
+    {
+        return STREAM_THREAD_IS_NOT_RUNNING;
+    }
+}
+
+int StreamingBoard::release_session ()
+{
+    if (initialized)
+    {
+        if (is_streaming)
+        {
+            stop_stream ();
+        }
+        initialized = false;
+        if (client)
+        {
+            delete client;
+            client = NULL;
+        }
+    }
+    return STATUS_OK;
+}
+
+void StreamingBoard::read_thread ()
+{
+    // format for incomming package is determined by original board
+    int num_channels = 0;
+    get_num_rows (board_id, &num_channels);
+    int bytes_per_recv = sizeof (double) * num_channels;
+    num_channels--;
+    int timestamp_channel = 0;
+    get_timestamp_channel (board_id, &timestamp_channel);
+    double *package = new double[num_channels];
+    int res = 0;
+
+    while (keep_alive)
+    {
+        res = client->recv (package, bytes_per_recv);
+        if (res != bytes_per_recv)
+        {
+            safe_logger (
+                spdlog::level::trace, "unable to read {} bytes, read {}", bytes_per_recv, res);
+            continue;
+        }
+
+        double timestamp = package[timestamp_channel];
+        streamer->stream_data (package, num_channels, timestamp);
+        db->add_data (timestamp,
+            package); // here package is bigger but add_data will not copy bytes for timestamp
+    }
+    delete[] package;
+}

--- a/src/board_controller/streaming_board.cpp
+++ b/src/board_controller/streaming_board.cpp
@@ -167,10 +167,10 @@ void StreamingBoard::read_thread ()
     int num_channels = 0;
     get_num_rows (board_id, &num_channels);
     int bytes_per_recv = sizeof (double) * num_channels;
+    double *package = new double[num_channels];
     num_channels--;
     int timestamp_channel = 0;
     get_timestamp_channel (board_id, &timestamp_channel);
-    double *package = new double[num_channels];
     int res = 0;
 
     while (keep_alive)

--- a/src/utils/multicast_client.cpp
+++ b/src/utils/multicast_client.cpp
@@ -40,7 +40,7 @@ int MultiCastClient::init ()
     // ensure that library will not hang in blocking recv/send call
     DWORD timeout = 5000;
     DWORD value = 1;
-    setsockopt (client_socket, SOL_SOCKET, SO_REUSEADDR, (char *)value, sizeof (value));
+    setsockopt (client_socket, SOL_SOCKET, SO_REUSEADDR, (char *)&value, sizeof (value));
     setsockopt (client_socket, SOL_SOCKET, SO_RCVTIMEO, (char *)&timeout, sizeof (timeout));
     setsockopt (client_socket, SOL_SOCKET, SO_SNDTIMEO, (char *)&timeout, sizeof (timeout));
 
@@ -116,7 +116,7 @@ int MultiCastClient::init ()
     tv.tv_sec = 5;
     tv.tv_usec = 0;
     int value = 1;
-    setsockopt (client_socket, SOL_SOCKET, SO_REUSEADDR, (char *)value, sizeof (value));
+    setsockopt (client_socket, SOL_SOCKET, SO_REUSEADDR, &value, sizeof (value));
     setsockopt (client_socket, SOL_SOCKET, SO_RCVTIMEO, (const char *)&tv, sizeof (tv));
     setsockopt (client_socket, SOL_SOCKET, SO_SNDTIMEO, (const char *)&tv, sizeof (tv));
 

--- a/src/utils/multicast_client.cpp
+++ b/src/utils/multicast_client.cpp
@@ -30,10 +30,7 @@ int MultiCastClient::init ()
     }
     socket_addr.sin_family = AF_INET;
     socket_addr.sin_port = htons (port);
-    if (inet_pton (AF_INET, ip_addr, &socket_addr.sin_addr) == 0)
-    {
-        return (int)MultiCastReturnCodes::PTON_ERROR;
-    }
+    socket_addr.sin_addr.s_addr = htonl (INADDR_ANY);
     client_socket = socket (AF_INET, SOCK_DGRAM, IPPROTO_UDP);
     if (client_socket == INVALID_SOCKET)
     {
@@ -112,10 +109,7 @@ int MultiCastClient::init ()
 
     socket_addr.sin_family = AF_INET;
     socket_addr.sin_port = htons (port);
-    if (inet_pton (AF_INET, ip_addr, &socket_addr.sin_addr) == 0)
-    {
-        return (int)MultiCastReturnCodes::PTON_ERROR;
-    }
+    socket_addr.sin_addr.s_addr = htonl (INADDR_ANY);
 
     // ensure that library will not hang in blocking recv/send call
     struct timeval tv;

--- a/tests/cpp/get_data_demo/src/brainflow_get_data.cpp
+++ b/tests/cpp/get_data_demo/src/brainflow_get_data.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <stdlib.h>
+#include <string>
 
 #ifdef _WIN32
 #include <windows.h>
@@ -49,6 +50,13 @@ int main (int argc, char *argv[])
         data = board->get_board_data (&data_count);
         BoardShim::log_message ((int)LogLevels::LEVEL_INFO, "read %d packages", data_count);
         board->release_session ();
+        // for STREAMING_BOARD you have to query information using board id for master board
+        // because for STREAMING_BOARD data format is determined by master board!
+        if (board_id == STREAMING_BOARD)
+        {
+            board_id = std::stoi (params.other_info);
+            BoardShim::log_message ((int)LogLevels::LEVEL_INFO, "Use Board Id %d", board_id);
+        }
         num_rows = BoardShim::get_num_rows (board_id);
         std::cout << std::endl << "Data from the board" << std::endl << std::endl;
         print_head (data, num_rows, data_count);


### PR DESCRIPTION
Signed-off-by: Andrey Parfenov <a1994ndrey@gmail.com>

Add streaming board. IMO its really cool feature.

To enable it run first process with start_stream(streamer_params = streaming_board://225.1.1.1:6677) You can write any valid multicast address and port here and in second process specify ip_address, ip_port, board_id and specify master board_id in other_info field