### PR TITLE
fix potential parsing issue for cyton

### DIFF
--- a/src/board_controller/openbci/cyton.cpp
+++ b/src/board_controller/openbci/cyton.cpp
@@ -48,6 +48,10 @@ void Cyton::read_thread ()
             remaining_bytes -= res;
             pos += res;
         }
+        if (!keep_alive)
+        {
+            return;
+        }
 
         if ((b[31] < END_BYTE_STANDARD) || (b[31] > END_BYTE_MAX))
         {

--- a/src/board_controller/openbci/cyton.cpp
+++ b/src/board_controller/openbci/cyton.cpp
@@ -40,12 +40,15 @@ void Cyton::read_thread ()
             continue;
         }
 
-        res = serial->read_from_serial_port (b, 32);
-        if (res != 32)
+        int remaining_bytes = 32;
+        int pos = 0;
+        while ((remaining_bytes > 0) && (keep_alive))
         {
-            safe_logger (spdlog::level::debug, "unable to read 32 bytes");
-            continue;
+            res = serial->read_from_serial_port (b + pos, remaining_bytes);
+            remaining_bytes -= res;
+            pos += res;
         }
+
         if ((b[31] < END_BYTE_STANDARD) || (b[31] > END_BYTE_MAX))
         {
             safe_logger (spdlog::level::warn, "Wrong end byte {}", b[31]);

--- a/src/board_controller/openbci/cyton_daisy.cpp
+++ b/src/board_controller/openbci/cyton_daisy.cpp
@@ -44,12 +44,15 @@ void CytonDaisy::read_thread ()
             continue;
         }
 
-        res = serial->read_from_serial_port (b, 32);
-        if (res != 32)
+        int remaining_bytes = 32;
+        int pos = 0;
+        while ((remaining_bytes > 0) && (keep_alive))
         {
-            safe_logger (spdlog::level::debug, "unable to read 31 bytes");
-            continue;
+            res = serial->read_from_serial_port (b + pos, remaining_bytes);
+            remaining_bytes -= res;
+            pos += res;
         }
+
         if ((b[31] < END_BYTE_STANDARD) || (b[31] > END_BYTE_MAX))
         {
             safe_logger (spdlog::level::warn, "Wrong end byte {}", b[31]);

--- a/src/board_controller/openbci/cyton_daisy.cpp
+++ b/src/board_controller/openbci/cyton_daisy.cpp
@@ -52,6 +52,10 @@ void CytonDaisy::read_thread ()
             remaining_bytes -= res;
             pos += res;
         }
+        if (!keep_alive)
+        {
+            return;
+        }
 
         if ((b[31] < END_BYTE_STANDARD) || (b[31] > END_BYTE_MAX))
         {

--- a/src/utils/inc/custom_cast.h
+++ b/src/utils/inc/custom_cast.h
@@ -3,25 +3,25 @@
 #include <bitset>
 #include <stdint.h>
 
+// copypasted from OpenBCI_JavaScript_Utilities
 inline int32_t cast_24bit_to_int32 (unsigned char *byte_array)
 {
-    int32_t new_int =
-        (((0xFF & byte_array[0]) << 16) | ((0xFF & byte_array[1]) << 8) | (0xFF & byte_array[2]));
-    if ((new_int & 0x00800000) > 0)
-        new_int |= 0xFF000000;
-    else
-        new_int &= 0x00FFFFFF;
-    return new_int;
+    int prefix = 0;
+    if (byte_array[0] > 127)
+    {
+        prefix = 255;
+    }
+    return (prefix << 24) | (byte_array[0] << 16) | (byte_array[1] << 8) | byte_array[2];
 }
 
 inline int32_t cast_16bit_to_int32 (unsigned char *byte_array)
 {
-    int32_t new_int = (((0xFF & byte_array[0]) << 8) | (0xFF & byte_array[1]));
-    if ((new_int & 0x00008000) > 0)
-        new_int |= 0xFFFF0000;
-    else
-        new_int &= 0x0000FFFF;
-    return new_int;
+    int prefix = 0;
+    if (byte_array[0] > 127)
+    {
+        prefix = 65535;
+    }
+    return (prefix << 16) | (byte_array[0] << 8) | byte_array[1];
 }
 
 inline void uchar_to_bits (unsigned char c, unsigned char *bits)

--- a/src/utils/serial.cpp
+++ b/src/utils/serial.cpp
@@ -84,6 +84,7 @@ int Serial::close_serial_port ()
     if (this->is_port_open ())
     {
         CloseHandle (this->port_descriptor);
+        this->port_descriptor = NULL;
     }
     return SerialExitCodes::OK;
 }
@@ -158,8 +159,11 @@ int Serial::close_serial_port ()
     if (this->is_port_open ())
     {
         int res = close (port_descriptor);
+        port_descriptor = 0;
         if (res < 0)
+        {
             return SerialExitCodes::CLOSE_ERROR;
+        }
     }
     return SerialExitCodes::OK;
 }


### PR DESCRIPTION
Signed-off-by: Andrey Parfenov <a1994ndrey@gmail.com>

changes in custom_cast.h are meaningless it looks like the same equation but lets write it exactly like here: https://github.com/OpenBCI/OpenBCI_JavaScript_Utilities/blob/master/src/utilities.js#L354 to avoid all possible questinos about parsing

Changes about reading data from serial port fix potential issue when there are less than 32 bytes