### PR TITLE
Fixing segfault when streaming ganglion on ubuntu

### DIFF
--- a/src/board_controller/openbci/ganglion_bglib/callbacks.cpp
+++ b/src/board_controller/openbci/ganglion_bglib/callbacks.cpp
@@ -188,7 +188,7 @@ void ble_evt_attclient_find_information_found (
 
 void ble_evt_attclient_attribute_value (const struct ble_msg_attclient_attribute_value_evt_t *msg)
 {
-    if ((int)msg->value.len >= 18)
+    if (((int)msg->value.len >= 18) && ((int)msg->value.len <= 20))
     {
         unsigned char values[20] = {0};
         memcpy (values, msg->value.data, msg->value.len * sizeof (unsigned char));

--- a/src/board_controller/openbci/ganglion_bglib/main.cpp
+++ b/src/board_controller/openbci/ganglion_bglib/main.cpp
@@ -1,6 +1,5 @@
 #include <chrono>
 #include <ctype.h>
-#include <mutex>
 #include <queue>
 #include <stdlib.h>
 #include <string.h>
@@ -28,11 +27,10 @@ namespace GanglionLib
     volatile uint16 client_char_handle = 0;
     volatile State state =
         State::NONE; // same callbacks are triggered by different methods we need to differ them
+    volatile bool should_stop_stream = true;
 
     bool initialized = false;
-    std::mutex mutex;
     std::thread read_characteristic_thread;
-    bool should_stop_stream = true;
 
     void read_characteristic_worker ()
     {

--- a/src/board_controller/openbci/ganglion_bglib/uart.cpp
+++ b/src/board_controller/openbci/ganglion_bglib/uart.cpp
@@ -1,5 +1,5 @@
 //
-// Bluegiga’s Bluetooth Smart Demo Application
+// Bluegigaï¿½s Bluetooth Smart Demo Application
 // Contact: support@bluegiga.com.
 //
 // This is free software distributed under the terms of the MIT license reproduced below.
@@ -179,7 +179,7 @@ int uart_tx (int len, unsigned char *data)
             return -1;
         }
         len -= written;
-        data += len;
+        data += written;
     }
 
     return 0;
@@ -213,7 +213,7 @@ int uart_rx (int len, unsigned char *data, int timeout_ms)
                 return 0;
         }
         len -= rread;
-        data += len;
+        data += rread;
     }
 
     return l;
@@ -296,7 +296,7 @@ int uart_tx (int len, unsigned char *data)
             return -1;
         }
         len -= written;
-        data += len;
+        data += written;
     }
 
     return 0;
@@ -325,7 +325,7 @@ int uart_rx (int len, unsigned char *data, int timeout_ms)
             return -1;
         }
         len -= rread;
-        data += len;
+        data += rread;
     }
 
     return l;


### PR DESCRIPTION
Fixed a bug in uart.cpp where a pointer wasn't properly incremented.
Dynamically allocate the data pointer to the exact size needed.
Added lock to read_message for safety

Haven't actually tested on windows yet but can do that before submitting