### PR TITLE
fix multiple set_log_file calls with the same filename

### DIFF
--- a/src/board_controller/board.cpp
+++ b/src/board_controller/board.cpp
@@ -10,6 +10,7 @@
 #define LOGGER_NAME "brainflow_logger"
 
 std::shared_ptr<spdlog::logger> Board::board_logger = spdlog::stderr_logger_mt (LOGGER_NAME);
+volatile bool Board::skip_logs = false;
 
 int Board::set_log_level (int level)
 {
@@ -29,11 +30,14 @@ int Board::set_log_level (int level)
 
 int Board::set_log_file (char *log_file)
 {
+    skip_logs = true; // we reset logger, ensure that streaming thread will not log using nullptr
     spdlog::level::level_enum level = Board::board_logger->level ();
+    Board::board_logger = nullptr;
     spdlog::drop (LOGGER_NAME);
     Board::board_logger = spdlog::basic_logger_mt (LOGGER_NAME, log_file);
     Board::board_logger->set_level (level);
     Board::board_logger->flush_on (level);
+    skip_logs = false;
     return STATUS_OK;
 }
 

--- a/src/board_controller/brainbit/brainbit.cpp
+++ b/src/board_controller/brainbit/brainbit.cpp
@@ -57,8 +57,9 @@ BrainBit::BrainBit (struct BrainFlowInputParams params) : Board ((int)BRAINBIT_B
 
 BrainBit::~BrainBit ()
 {
-    skip_logs = true;
+    Board::skip_logs = true;
     release_session ();
+    Board::skip_logs = false;
 }
 
 int BrainBit::prepare_session ()

--- a/src/board_controller/inc/board.h
+++ b/src/board_controller/inc/board.h
@@ -27,7 +27,6 @@ public:
     }
     Board (int board_id, struct BrainFlowInputParams params)
     {
-        skip_logs = false;
         db = NULL;       // should be initialized in start_stream
         streamer = NULL; // should be initialized in start_stream
         this->board_id = board_id;
@@ -50,7 +49,7 @@ public:
     void safe_logger (spdlog::level::level_enum log_level, const char *fmt, const Arg1 &arg1,
         const Args &... args)
     {
-        if (!skip_logs)
+        if (!Board::skip_logs)
         {
             Board::board_logger->log (log_level, fmt, arg1, args...);
         }
@@ -58,7 +57,7 @@ public:
 
     template <typename T> void safe_logger (spdlog::level::level_enum log_level, const T &msg)
     {
-        if (!skip_logs)
+        if (!Board::skip_logs)
         {
             Board::board_logger->log (log_level, msg);
         }
@@ -66,7 +65,7 @@ public:
 
 protected:
     DataBuffer *db;
-    bool skip_logs;
+    static volatile bool skip_logs;
     int board_id;
     struct BrainFlowInputParams params;
     Streamer *streamer;

--- a/src/board_controller/openbci/ganglion.cpp
+++ b/src/board_controller/openbci/ganglion.cpp
@@ -39,9 +39,10 @@ Ganglion::Ganglion (struct BrainFlowInputParams params) : Board ((int)GANGLION_B
 
 Ganglion::~Ganglion ()
 {
-    skip_logs = true;
+    Board::skip_logs = true;
     Ganglion::num_objects--;
     release_session ();
+    Board::skip_logs = false;
 }
 
 int Ganglion::prepare_session ()

--- a/src/board_controller/openbci/novaxr.cpp
+++ b/src/board_controller/openbci/novaxr.cpp
@@ -28,8 +28,9 @@ NovaXR::NovaXR (struct BrainFlowInputParams params) : Board ((int)NOVAXR_BOARD, 
 
 NovaXR::~NovaXR ()
 {
-    skip_logs = true;
+    Board::skip_logs = true;
     release_session ();
+    Board::skip_logs = false;
 }
 
 int NovaXR::prepare_session ()

--- a/src/board_controller/openbci/openbci_serial_board.cpp
+++ b/src/board_controller/openbci/openbci_serial_board.cpp
@@ -17,8 +17,9 @@ OpenBCISerialBoard::OpenBCISerialBoard (
 
 OpenBCISerialBoard::~OpenBCISerialBoard ()
 {
-    skip_logs = true;
+    Board::skip_logs = true;
     release_session ();
+    Board::skip_logs = false;
 }
 
 int OpenBCISerialBoard::open_port ()

--- a/src/board_controller/openbci/openbci_wifi_shield_board.cpp
+++ b/src/board_controller/openbci/openbci_wifi_shield_board.cpp
@@ -28,8 +28,9 @@ OpenBCIWifiShieldBoard::OpenBCIWifiShieldBoard (
 
 OpenBCIWifiShieldBoard::~OpenBCIWifiShieldBoard ()
 {
-    skip_logs = true;
+    Board::skip_logs = true;
     release_session ();
+    Board::skip_logs = false;
 }
 
 int OpenBCIWifiShieldBoard::prepare_session ()

--- a/src/board_controller/streaming_board.cpp
+++ b/src/board_controller/streaming_board.cpp
@@ -22,8 +22,9 @@ StreamingBoard::StreamingBoard (struct BrainFlowInputParams params)
 
 StreamingBoard::~StreamingBoard ()
 {
-    skip_logs = true;
+    Board::skip_logs = true;
     release_session ();
+    Board::skip_logs = false;
 }
 
 int StreamingBoard::prepare_session ()

--- a/src/board_controller/synthetic_board.cpp
+++ b/src/board_controller/synthetic_board.cpp
@@ -34,8 +34,9 @@ SyntheticBoard::SyntheticBoard (struct BrainFlowInputParams params)
 
 SyntheticBoard::~SyntheticBoard ()
 {
-    skip_logs = true;
+    Board::skip_logs = true;
     release_session ();
+    Board::skip_logs = false;
 }
 
 


### PR DESCRIPTION
Signed-off-by: Andrey Parfenov <a1994ndrey@gmail.com>

I didnt reset logger pointer to null and due to it file handle was not closed. It caused an error if multiple set_log_file invocations used same filename. Solution - set pointer to null and call drop after that.

To avoid raice confition in streaming thread and in set_log_file added log guard and made it static since set_log_file method is static and its correct.

To handle case if multiple boards are created and we call destructor for one of them we need to restore skip_logs flag in the end of destructor.

```
    Board::skip_logs = true;
    release_session ();
    Board::skip_logs = false;
```
In terms of code its not perfect but it should be reliable.

Also I think its related to https://github.com/OpenBCI/OpenBCI_GUI/pull/691 and unity player issue which I had with set_log_file before

