### PR TITLE
dont export symbols on unix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,10 @@ set (CMAKE_CXX_STANDARD 11)
 set (CMAKE_VERBOSE_MAKEFILE ON)
 set (BRAINFLOW_VERSION 2.1.0)
 
+# dont export sumbols on unix by default
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+set(CMAKE_C_VISIBILITY_PRESET hidden)
+
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 macro (configure_msvc_runtime)

--- a/src/board_controller/inc/board_controller.h
+++ b/src/board_controller/inc/board_controller.h
@@ -7,7 +7,7 @@
 #define SHARED_EXPORT __declspec(dllexport)
 #define CALLING_CONVENTION __cdecl
 #else
-#define SHARED_EXPORT
+#define SHARED_EXPORT __attribute__((visibility("default")))
 #define CALLING_CONVENTION
 #endif
 

--- a/src/board_controller/inc/board_info_getter.h
+++ b/src/board_controller/inc/board_info_getter.h
@@ -4,7 +4,7 @@
 #define SHARED_EXPORT __declspec(dllexport)
 #define CALLING_CONVENTION __cdecl
 #else
-#define SHARED_EXPORT
+#define SHARED_EXPORT __attribute__((visibility("default")))
 #define CALLING_CONVENTION
 #endif
 

--- a/src/data_handler/inc/data_handler.h
+++ b/src/data_handler/inc/data_handler.h
@@ -2,8 +2,10 @@
 
 #ifdef _WIN32
 #define SHARED_EXPORT __declspec(dllexport)
+#define CALLING_CONVENTION __cdecl
 #else
-#define SHARED_EXPORT
+#define SHARED_EXPORT __attribute__((visibility("default")))
+#define CALLING_CONVENTION
 #endif
 
 #include "brainflow_constants.h"
@@ -33,40 +35,40 @@ extern "C"
 #endif
     // signal processing methods
     // ripple param is used only for chebyshev filter
-    SHARED_EXPORT int perform_lowpass (double *data, int data_len, int sampling_rate, double cutoff,
+    SHARED_EXPORT int CALLING_CONVENTION perform_lowpass (double *data, int data_len, int sampling_rate, double cutoff,
         int order, int filter_type, double ripple);
-    SHARED_EXPORT int perform_highpass (double *data, int data_len, int sampling_rate,
+    SHARED_EXPORT int CALLING_CONVENTION perform_highpass (double *data, int data_len, int sampling_rate,
         double cutoff, int order, int filter_type, double ripple);
-    SHARED_EXPORT int perform_bandpass (double *data, int data_len, int sampling_rate,
+    SHARED_EXPORT int CALLING_CONVENTION perform_bandpass (double *data, int data_len, int sampling_rate,
         double center_freq, double band_width, int order, int filter_type, double ripple);
-    SHARED_EXPORT int perform_bandstop (double *data, int data_len, int sampling_rate,
+    SHARED_EXPORT int CALLING_CONVENTION perform_bandstop (double *data, int data_len, int sampling_rate,
         double center_freq, double band_width, int order, int filter_type, double ripple);
 
-    SHARED_EXPORT int perform_rolling_filter (
+    SHARED_EXPORT int CALLING_CONVENTION perform_rolling_filter (
         double *data, int data_len, int period, int agg_operation);
 
-    SHARED_EXPORT int perform_downsampling (
+    SHARED_EXPORT int CALLING_CONVENTION perform_downsampling (
         double *data, int data_len, int period, int agg_operation, double *output_data);
 
-    SHARED_EXPORT int perform_wavelet_transform (double *data, int data_len, char *wavelet,
+    SHARED_EXPORT int CALLING_CONVENTION perform_wavelet_transform (double *data, int data_len, char *wavelet,
         int decomposition_level, double *output_data, int *decomposition_lengths);
-    SHARED_EXPORT int perform_inverse_wavelet_transform (double *wavelet_coeffs,
+    SHARED_EXPORT int CALLING_CONVENTION perform_inverse_wavelet_transform (double *wavelet_coeffs,
         int original_data_len, char *wavelet, int decomposition_level, int *decomposition_lengths,
         double *output_data);
-    SHARED_EXPORT int perform_wavelet_denoising (
+    SHARED_EXPORT int CALLING_CONVENTION perform_wavelet_denoising (
         double *data, int data_len, char *wavelet, int decomposition_level);
-    SHARED_EXPORT int perform_fft (
+    SHARED_EXPORT int CALLING_CONVENTION perform_fft (
         double *data, int data_len, double *output_re, double *output_im);
-    SHARED_EXPORT int perform_ifft (
+    SHARED_EXPORT int CALLING_CONVENTION perform_ifft (
         double *input_re, double *input_im, int data_len, double *restored_data);
 
 
     // file operations
-    SHARED_EXPORT int write_file (
+    SHARED_EXPORT int CALLING_CONVENTION write_file (
         double *data, int num_rows, int num_cols, char *file_name, char *file_mode);
-    SHARED_EXPORT int read_file (
+    SHARED_EXPORT int CALLING_CONVENTION read_file (
         double *data, int *num_rows, int *num_cols, char *file_name, int num_elements);
-    SHARED_EXPORT int get_num_elements_in_file (
+    SHARED_EXPORT int CALLING_CONVENTION get_num_elements_in_file (
         char *file_name, int *num_elements); // its an internal method for bindings its not
                                              // available via high level api
 #ifdef __cplusplus


### PR DESCRIPTION
Signed-off-by: Andrey1994 <a1994ndrey@gmail.com>

This fix together with https://github.com/OpenBCI/OpenBCI_GUI_Helpers/pull/1 solves the issue with ganglion + unix in OpenBCI GUI

I will update jars in openbci gui as soon as we merge it