### PR TITLE
Fix cyton accel data delivery

### DIFF
--- a/src/board_controller/openbci/cyton.cpp
+++ b/src/board_controller/openbci/cyton.cpp
@@ -26,6 +26,7 @@ void Cyton::read_thread ()
     */
     int res;
     unsigned char b[32];
+    double accel[3] = {0.};
     while (keep_alive)
     {
         // check start byte
@@ -79,10 +80,24 @@ void Cyton::read_thread ()
         // place processed bytes for accel
         if (b[31] == END_BYTE_STANDARD)
         {
-            package[9] = accel_scale * cast_16bit_to_int32 (b + 25);
-            package[10] = accel_scale * cast_16bit_to_int32 (b + 27);
-            package[11] = accel_scale * cast_16bit_to_int32 (b + 29);
+            double accelTemp[3] = {0.};
+            accelTemp[0] = accel_scale * cast_16bit_to_int32 (b + 25);
+            accelTemp[1] = accel_scale * cast_16bit_to_int32 (b + 27);
+            accelTemp[2] = accel_scale * cast_16bit_to_int32 (b + 29);
+
+            for (int i = 0; i < 3; i++)
+            {
+                if (accelTemp[i] != 0)
+                {
+                    accel[i] = accelTemp[i];
+                }
+            }
+
+            package[9] = accel[0];
+            package[10] = accel[1];
+            package[11] = accel[2];
         }
+
         // place processed bytes for analog
         if (b[31] == END_BYTE_ANALOG)
         {

--- a/src/board_controller/openbci/cyton.cpp
+++ b/src/board_controller/openbci/cyton.cpp
@@ -80,17 +80,16 @@ void Cyton::read_thread ()
         // place processed bytes for accel
         if (b[31] == END_BYTE_STANDARD)
         {
-            double accelTemp[3] = {0.};
-            accelTemp[0] = accel_scale * cast_16bit_to_int32 (b + 25);
-            accelTemp[1] = accel_scale * cast_16bit_to_int32 (b + 27);
-            accelTemp[2] = accel_scale * cast_16bit_to_int32 (b + 29);
+            int32_t accel_temp[3] = {0};
+            accel_temp[0] = cast_16bit_to_int32 (b + 25);
+            accel_temp[1] = cast_16bit_to_int32 (b + 27);
+            accel_temp[2] = cast_16bit_to_int32 (b + 29);
 
-            for (int i = 0; i < 3; i++)
+            if (accel_temp[0] != 0)
             {
-                if (accelTemp[i] != 0)
-                {
-                    accel[i] = accelTemp[i];
-                }
+                accel[0] = accel_scale * accel_temp[0];
+                accel[1] = accel_scale * accel_temp[1];
+                accel[2] = accel_scale * accel_temp[2];
             }
 
             package[9] = accel[0];

--- a/src/board_controller/openbci/cyton_daisy.cpp
+++ b/src/board_controller/openbci/cyton_daisy.cpp
@@ -30,6 +30,7 @@ void CytonDaisy::read_thread ()
     unsigned char b[32];
     double package[30] = {0.};
     bool first_sample = false;
+    double accel[3] = {0.};
     while (keep_alive)
     {
         // check start byte
@@ -107,15 +108,22 @@ void CytonDaisy::read_thread ()
         // place processed accel data
         if (b[31] == END_BYTE_STANDARD)
         {
+            double accelTemp[3] = {0.};
+            accelTemp[0] = accel_scale * cast_16bit_to_int32 (b + 25);
+            accelTemp[1] = accel_scale * cast_16bit_to_int32 (b + 27);
+            accelTemp[2] = accel_scale * cast_16bit_to_int32 (b + 29);
+
             if ((b[0] % 2 == 0) && (first_sample))
             {
                 // need to average accel data
-                package[17] += accel_scale * cast_16bit_to_int32 (b + 25);
-                package[18] += accel_scale * cast_16bit_to_int32 (b + 27);
-                package[19] += accel_scale * cast_16bit_to_int32 (b + 29);
-                package[17] /= 2.0f;
-                package[18] /= 2.0f;
-                package[19] /= 2.0f;
+                for (int i = 0; i < 3; i++)
+                {
+                    if (accelTemp[i] != 0)
+                    {
+                        accel[i] += accelTemp[i];
+                        accel[i] /= 2.f;
+                    }
+                }
                 package[20] = (double)b[31];
             }
             else
@@ -123,10 +131,18 @@ void CytonDaisy::read_thread ()
                 first_sample = true;
                 package[0] = (double)b[0];
                 // accel
-                package[17] = accel_scale * cast_16bit_to_int32 (b + 25);
-                package[18] = accel_scale * cast_16bit_to_int32 (b + 27);
-                package[19] = accel_scale * cast_16bit_to_int32 (b + 29);
+                for (int i = 0; i < 3; i++)
+                {
+                    if (accelTemp[i] != 0)
+                    {
+                        accel[i] = accelTemp[i];
+                    }
+                }
             }
+
+            package[17] = accel[0];
+            package[18] = accel[1];
+            package[19] = accel[2];
         }
         // place processed analog data
         if (b[31] == END_BYTE_ANALOG)

--- a/src/board_controller/openbci/cyton_daisy.cpp
+++ b/src/board_controller/openbci/cyton_daisy.cpp
@@ -108,22 +108,25 @@ void CytonDaisy::read_thread ()
         // place processed accel data
         if (b[31] == END_BYTE_STANDARD)
         {
-            double accelTemp[3] = {0.};
-            accelTemp[0] = accel_scale * cast_16bit_to_int32 (b + 25);
-            accelTemp[1] = accel_scale * cast_16bit_to_int32 (b + 27);
-            accelTemp[2] = accel_scale * cast_16bit_to_int32 (b + 29);
+            int32_t accel_temp[3] = {0};
+            accel_temp[0] = cast_16bit_to_int32 (b + 25);
+            accel_temp[1] = cast_16bit_to_int32 (b + 27);
+            accel_temp[2] = cast_16bit_to_int32 (b + 29);
 
             if ((b[0] % 2 == 0) && (first_sample))
             {
                 // need to average accel data
-                for (int i = 0; i < 3; i++)
+                if (accel_temp[0] != 0)
                 {
-                    if (accelTemp[i] != 0)
-                    {
-                        accel[i] += accelTemp[i];
-                        accel[i] /= 2.f;
-                    }
+                    accel[0] += accel_scale * accel_temp[0];
+                    accel[1] += accel_scale * accel_temp[1];
+                    accel[2] += accel_scale * accel_temp[2];
+
+                    accel[0] /= 2.f;
+                    accel[1] /= 2.f;
+                    accel[2] /= 2.f;
                 }
+
                 package[20] = (double)b[31];
             }
             else
@@ -131,12 +134,11 @@ void CytonDaisy::read_thread ()
                 first_sample = true;
                 package[0] = (double)b[0];
                 // accel
-                for (int i = 0; i < 3; i++)
+                if (accel_temp[0] != 0)
                 {
-                    if (accelTemp[i] != 0)
-                    {
-                        accel[i] = accelTemp[i];
-                    }
+                    accel[0] = accel_scale * accel_temp[0];
+                    accel[1] = accel_scale * accel_temp[1];
+                    accel[2] = accel_scale * accel_temp[2];
                 }
             }
 

--- a/src/board_controller/openbci/cyton_daisy_wifi.cpp
+++ b/src/board_controller/openbci/cyton_daisy_wifi.cpp
@@ -99,21 +99,23 @@ void CytonDaisyWifi::read_thread ()
             // place processed accel data
             if (bytes[31 + offset] == END_BYTE_STANDARD)
             {
-                double accelTemp[3] = {0.};
-                accelTemp[0] = accel_scale * cast_16bit_to_int32 (bytes + 25 + offset);
-                accelTemp[1] = accel_scale * cast_16bit_to_int32 (bytes + 27 + offset);
-                accelTemp[2] = accel_scale * cast_16bit_to_int32 (bytes + 29 + offset);
+                int32_t accel_temp[3] = {0};
+                accel_temp[0] = cast_16bit_to_int32 (bytes + 25 + offset);
+                accel_temp[1] = cast_16bit_to_int32 (bytes + 27 + offset);
+                accel_temp[2] = cast_16bit_to_int32 (bytes + 29 + offset);
 
                 if ((bytes[0 + offset] % 2 == 0) && (first_sample))
                 {
                     // need to average accel data
-                    for (int i = 0; i < 3; i++)
+                    if (accel_temp[0] != 0)
                     {
-                        if (accelTemp[i] != 0)
-                        {
-                            accel[i] += accelTemp[i];
-                            accel[i] /= 2.f;
-                        }
+                        accel[0] += accel_scale * accel_temp[0];
+                        accel[1] += accel_scale * accel_temp[1];
+                        accel[2] += accel_scale * accel_temp[2];
+
+                        accel[0] /= 2.f;
+                        accel[1] /= 2.f;
+                        accel[2] /= 2.f;
                     }
 
                     package[20] = (double)bytes[31 + offset];
@@ -124,12 +126,11 @@ void CytonDaisyWifi::read_thread ()
                     package[0] = (double)bytes[0 + offset];
 
                     // accel
-                    for (int i = 0; i < 3; i++)
+                    if (accel_temp[0] != 0)
                     {
-                        if (accelTemp[i] != 0)
-                        {
-                            accel[i] = accelTemp[i];
-                        }
+                        accel[0] = accel_scale * accel_temp[0];
+                        accel[1] = accel_scale * accel_temp[1];
+                        accel[2] = accel_scale * accel_temp[2];
                     }
                 }
 

--- a/src/board_controller/openbci/cyton_wifi.cpp
+++ b/src/board_controller/openbci/cyton_wifi.cpp
@@ -72,17 +72,16 @@ void CytonWifi::read_thread ()
             // place processed bytes for accel
             if (bytes[31 + offset] == END_BYTE_STANDARD)
             {
-                double accelTemp[3] = {0.};
-                accelTemp[0] = accel_scale * cast_16bit_to_int32 (bytes + 25 + offset);
-                accelTemp[1] = accel_scale * cast_16bit_to_int32 (bytes + 27 + offset);
-                accelTemp[2] = accel_scale * cast_16bit_to_int32 (bytes + 29 + offset);
+                int32_t accel_temp[3] = {0};
+                accel_temp[0] = cast_16bit_to_int32 (bytes + 25 + offset);
+                accel_temp[1] = cast_16bit_to_int32 (bytes + 27 + offset);
+                accel_temp[2] = cast_16bit_to_int32 (bytes + 29 + offset);
 
-                for (int i = 0; i < 3; i++)
+                if (accel_temp[0] != 0)
                 {
-                    if (accelTemp[i] != 0)
-                    {
-                        accel[i] = accelTemp[i];
-                    }
+                    accel[0] = accel_scale * accel_temp[0];
+                    accel[1] = accel_scale * accel_temp[1];
+                    accel[2] = accel_scale * accel_temp[2];
                 }
 
                 package[9] = accel[0];

--- a/src/board_controller/openbci/cyton_wifi.cpp
+++ b/src/board_controller/openbci/cyton_wifi.cpp
@@ -27,6 +27,7 @@ void CytonWifi::read_thread ()
     */
     int res;
     unsigned char b[OpenBCIWifiShieldBoard::transaction_size];
+    double accel[3] = {0.};
     while (keep_alive)
     {
         // check start byte
@@ -71,9 +72,22 @@ void CytonWifi::read_thread ()
             // place processed bytes for accel
             if (bytes[31 + offset] == END_BYTE_STANDARD)
             {
-                package[9] = accel_scale * cast_16bit_to_int32 (bytes + 25 + offset);
-                package[10] = accel_scale * cast_16bit_to_int32 (bytes + 27 + offset);
-                package[11] = accel_scale * cast_16bit_to_int32 (bytes + 29 + offset);
+                double accelTemp[3] = {0.};
+                accelTemp[0] = accel_scale * cast_16bit_to_int32 (bytes + 25 + offset);
+                accelTemp[1] = accel_scale * cast_16bit_to_int32 (bytes + 27 + offset);
+                accelTemp[2] = accel_scale * cast_16bit_to_int32 (bytes + 29 + offset);
+
+                for (int i = 0; i < 3; i++)
+                {
+                    if (accelTemp[i] != 0)
+                    {
+                        accel[i] = accelTemp[i];
+                    }
+                }
+
+                package[9] = accel[0];
+                package[10] = accel[1];
+                package[11] = accel[2];
             }
             // place processed bytes for analog
             if (bytes[31 + offset] == END_BYTE_ANALOG)


### PR DESCRIPTION
Before this PR, cyton accel data was zero 9/10 samples. Instead of zeroes, repeat the previous accel values. Fix applied to all 4 cyton boards.