### PR TITLE
Changes to support brainflow CSharp on Linux using Mono framework

### DIFF
--- a/csharp-package/brainflow/brainflow/PlatformHelper.cs
+++ b/csharp-package/brainflow/brainflow/PlatformHelper.cs
@@ -1,0 +1,43 @@
+﻿using System;
+
+namespace brainflow
+{
+    public enum LibraryEnvironment
+    {
+        Unknown,
+        Linux,
+        x86,
+        x64,
+    }
+
+    public static class PlatformHelper
+    {
+        public static LibraryEnvironment GetLibraryEnvironment()
+        {
+            if (_LibraryEnvironment == LibraryEnvironment.Unknown)
+            {
+                switch (Environment.OSVersion.Platform)
+                {
+                    case PlatformID.Unix:
+                    case PlatformID.MacOSX:
+                        _LibraryEnvironment = LibraryEnvironment.Linux;
+                        break;
+
+                    default:
+                        {
+                            if (Environment.Is64BitProcess)
+                                _LibraryEnvironment = LibraryEnvironment.x64;
+                            else
+                                _LibraryEnvironment = LibraryEnvironment.x86;
+                        }
+                        break;
+                }
+            }
+
+            return _LibraryEnvironment;
+        }
+
+        private static LibraryEnvironment _LibraryEnvironment = LibraryEnvironment.Unknown;
+    }
+}
+

--- a/csharp-package/brainflow/brainflow/board_controller_library.cs
+++ b/csharp-package/brainflow/brainflow/board_controller_library.cs
@@ -202,254 +202,537 @@ namespace brainflow
         public static extern int get_exg_channels (int board_id, int[] channels, int[] len);
     }
 
+    public static class BoardControllerLibraryLinux
+    {
+        [DllImport("libBoardController.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int prepare_session(int board_id, string input_json);
+        [DllImport("libBoardController.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int start_stream(int buffer_size, string streamer_params, int board_id, string input_json);
+        [DllImport("libBoardController.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int stop_stream(int board_id, string input_json);
+        [DllImport("libBoardController.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int release_session(int board_id, string input_json);
+        [DllImport("libBoardController.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int get_current_board_data(int num_samples, double[] data_buf, int[] returned_samples, int board_id, string input_json);
+        [DllImport("libBoardController.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int get_board_data_count(int[] result, int board_id, string input_json);
+        [DllImport("libBoardController.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int get_board_data(int data_count, double[] data_buf, int board_id, string input_json);
+        [DllImport("libBoardController.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int set_log_level(int log_level);
+        [DllImport("libBoardController.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int log_message(int log_level, string message);
+        [DllImport("libBoardController.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int config_board(string config, byte[] response, int[] len, int board_id, string input_json);
+        [DllImport("libBoardController.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int set_log_file(string log_file);
+        [DllImport("libBoardController.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int get_sampling_rate(int board_id, int[] sampling_rate);
+        [DllImport("libBoardController.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int get_timestamp_channel(int board_id, int[] timestamp_channel);
+        [DllImport("libBoardController.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int get_package_num_channel(int board_id, int[] package_num_channel);
+        [DllImport("libBoardController.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int get_battery_channel(int board_id, int[] battery_channel);
+        [DllImport("libBoardController.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int get_num_rows(int board_id, int[] num_rows);
+        [DllImport("libBoardController.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int get_eeg_channels(int board_id, int[] channels, int[] len);
+        [DllImport("libBoardController.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int get_emg_channels(int board_id, int[] channels, int[] len);
+        [DllImport("libBoardController.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int get_ecg_channels(int board_id, int[] channels, int[] len);
+        [DllImport("libBoardController.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int get_eog_channels(int board_id, int[] channels, int[] len);
+        [DllImport("libBoardController.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int get_eda_channels(int board_id, int[] channels, int[] len);
+        [DllImport("libBoardController.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int get_ppg_channels(int board_id, int[] channels, int[] len);
+        [DllImport("libBoardController.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int get_accel_channels(int board_id, int[] channels, int[] len);
+        [DllImport("libBoardController.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int get_analog_channels(int board_id, int[] channels, int[] len);
+        [DllImport("libBoardController.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int get_gyro_channels(int board_id, int[] channels, int[] len);
+        [DllImport("libBoardController.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int get_other_channels(int board_id, int[] channels, int[] len);
+        [DllImport("libBoardController.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int get_temperature_channels(int board_id, int[] channels, int[] len);
+        [DllImport("libBoardController.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int is_prepared(int[] prepared, int board_id, string input_json);
+        [DllImport("libBoardController.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int get_eeg_names(int board_id, byte[] eeg_names, int[] len);
+        [DllImport("libBoardController.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int get_resistance_channels(int board_id, int[] channels, int[] len);
+        [DllImport("libBoardController.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int get_exg_channels(int board_id, int[] channels, int[] len);
+    }
+    
     public static class BoardControllerLibrary
     {
         public static int prepare_session (int board_id, string input_json)
         {
-            if (System.Environment.Is64BitProcess)
-                return BoardControllerLibrary64.prepare_session (board_id, input_json);
-            else
-                return BoardControllerLibrary32.prepare_session (board_id, input_json);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return BoardControllerLibrary64.prepare_session(board_id, input_json);
+                case LibraryEnvironment.x86:
+                    return BoardControllerLibrary32.prepare_session(board_id, input_json);
+                case LibraryEnvironment.Linux:
+                    return BoardControllerLibraryLinux.prepare_session(board_id, input_json);
+            }
+
+            return -1;
         }
 
         public static int start_stream (int buffer_size, string streamer_params, int board_id, string input_json)
         {
-            if (System.Environment.Is64BitProcess)
-                return BoardControllerLibrary64.start_stream (buffer_size, streamer_params, board_id, input_json);
-            else
-                return BoardControllerLibrary32.start_stream (buffer_size, streamer_params, board_id, input_json);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return BoardControllerLibrary64.start_stream(buffer_size, streamer_params, board_id, input_json);
+                case LibraryEnvironment.x86:
+                    return BoardControllerLibrary32.start_stream(buffer_size, streamer_params, board_id, input_json);
+                case LibraryEnvironment.Linux:
+                    return BoardControllerLibraryLinux.start_stream(buffer_size, streamer_params, board_id, input_json);
+            }
+
+            return -1;
         }
 
         public static int stop_stream (int board_id, string input_json)
         {
-            if (System.Environment.Is64BitProcess)
-                return BoardControllerLibrary64.stop_stream (board_id, input_json);
-            else
-                return BoardControllerLibrary32.stop_stream (board_id, input_json);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return BoardControllerLibrary64.stop_stream(board_id, input_json);
+                case LibraryEnvironment.x86:
+                    return BoardControllerLibrary32.stop_stream(board_id, input_json);
+                case LibraryEnvironment.Linux:
+                    return BoardControllerLibraryLinux.stop_stream(board_id, input_json);
+            }
+
+            return -1;
         }
 
         public static int release_session (int board_id, string input_json)
         {
-            if (System.Environment.Is64BitProcess)
-                return BoardControllerLibrary64.release_session (board_id, input_json);
-            else
-                return BoardControllerLibrary32.release_session (board_id, input_json);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return BoardControllerLibrary64.release_session(board_id, input_json);
+                case LibraryEnvironment.x86:
+                    return BoardControllerLibrary32.release_session(board_id, input_json);
+                case LibraryEnvironment.Linux:
+                    return BoardControllerLibraryLinux.release_session(board_id, input_json);
+            }
+
+            return -1;
         }
 
         public static int get_current_board_data (int num_samples, double[] data_buf, int[] returned_samples, int board_id, string input_json)
         {
-            if (System.Environment.Is64BitProcess)
-                return BoardControllerLibrary64.get_current_board_data (num_samples, data_buf, returned_samples, board_id, input_json);
-            else
-                return BoardControllerLibrary32.get_current_board_data (num_samples, data_buf, returned_samples, board_id, input_json);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return BoardControllerLibrary64.get_current_board_data(num_samples, data_buf, returned_samples, board_id, input_json);
+                case LibraryEnvironment.x86:
+                    return BoardControllerLibrary32.get_current_board_data(num_samples, data_buf, returned_samples, board_id, input_json);
+                case LibraryEnvironment.Linux:
+                    return BoardControllerLibraryLinux.get_current_board_data(num_samples, data_buf, returned_samples, board_id, input_json);
+            }
+
+            return -1;
         }
 
         public static int get_board_data_count (int[] result, int board_id, string input_json)
         {
-            if (System.Environment.Is64BitProcess)
-                return BoardControllerLibrary64.get_board_data_count (result, board_id, input_json);
-            else
-                return BoardControllerLibrary32.get_board_data_count (result, board_id, input_json);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return BoardControllerLibrary64.get_board_data_count(result, board_id, input_json);
+                case LibraryEnvironment.x86:
+                    return BoardControllerLibrary32.get_board_data_count(result, board_id, input_json);
+                case LibraryEnvironment.Linux:
+                    return BoardControllerLibraryLinux.get_board_data_count(result, board_id, input_json);
+            }
+
+            return -1;
         }
 
         public static int is_prepared(int[] result, int board_id, string input_json)
         {
-            if (System.Environment.Is64BitProcess)
-                return BoardControllerLibrary64.is_prepared(result, board_id, input_json);
-            else
-                return BoardControllerLibrary32.is_prepared(result, board_id, input_json);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return BoardControllerLibrary64.is_prepared(result, board_id, input_json);
+                case LibraryEnvironment.x86:
+                    return BoardControllerLibrary32.is_prepared(result, board_id, input_json);
+                case LibraryEnvironment.Linux:
+                    return BoardControllerLibraryLinux.is_prepared(result, board_id, input_json);
+            }
+
+            return -1;
         }
 
         public static int get_board_data (int data_count, double[] data_buf, int board_id, string input_json)
         {
-            if (System.Environment.Is64BitProcess)
-                return BoardControllerLibrary64.get_board_data (data_count, data_buf, board_id, input_json);
-            else
-                return BoardControllerLibrary32.get_board_data (data_count, data_buf, board_id, input_json);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return BoardControllerLibrary64.get_board_data(data_count, data_buf, board_id, input_json);
+                case LibraryEnvironment.x86:
+                    return BoardControllerLibrary32.get_board_data(data_count, data_buf, board_id, input_json);
+                case LibraryEnvironment.Linux:
+                    return BoardControllerLibraryLinux.get_board_data(data_count, data_buf, board_id, input_json);
+            }
+
+            return -1;
         }
 
         public static int set_log_level (int log_level)
         {
-            if (System.Environment.Is64BitProcess)
-                return BoardControllerLibrary64.set_log_level (log_level);
-            else
-                return BoardControllerLibrary32.set_log_level (log_level);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return BoardControllerLibrary64.set_log_level(log_level);
+                case LibraryEnvironment.x86:
+                    return BoardControllerLibrary32.set_log_level(log_level);
+                case LibraryEnvironment.Linux:
+                    return BoardControllerLibraryLinux.set_log_level(log_level);
+            }
+
+            return -1;
         }
 
         public static int log_message (int log_level, string message)
         {
-            if (System.Environment.Is64BitProcess)
-                return BoardControllerLibrary64.log_message (log_level, message);
-            else
-                return BoardControllerLibrary32.log_message (log_level, message);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return BoardControllerLibrary64.log_message(log_level, message);
+                case LibraryEnvironment.x86:
+                    return BoardControllerLibrary32.log_message(log_level, message);
+                case LibraryEnvironment.Linux:
+                    return BoardControllerLibraryLinux.log_message(log_level, message);
+            }
+
+            return -1;
         }
 
         public static int config_board (string config, byte[] str, int[] len, int board_id, string input_json)
         {
-            if (System.Environment.Is64BitProcess)
-                return BoardControllerLibrary64.config_board (config, str, len, board_id, input_json);
-            else
-                return BoardControllerLibrary32.config_board (config, str, len, board_id, input_json);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return BoardControllerLibrary64.config_board(config, str, len, board_id, input_json);
+                case LibraryEnvironment.x86:
+                    return BoardControllerLibrary32.config_board(config, str, len, board_id, input_json);
+                case LibraryEnvironment.Linux:
+                    return BoardControllerLibraryLinux.config_board(config, str, len, board_id, input_json);
+            }
+
+            return -1;
         }
 
         public static int set_log_file (string log_file)
         {
-            if (System.Environment.Is64BitProcess)
-                return BoardControllerLibrary64.set_log_file (log_file);
-            else
-                return BoardControllerLibrary32.set_log_file (log_file);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return BoardControllerLibrary64.set_log_file(log_file);
+                case LibraryEnvironment.x86:
+                    return BoardControllerLibrary32.set_log_file(log_file);
+                case LibraryEnvironment.Linux:
+                    return BoardControllerLibraryLinux.set_log_file(log_file);
+            }
+
+            return -1;
         }
-   
+
         public static int get_sampling_rate (int board_id, int[] sampling_rate)
         {
-            if (System.Environment.Is64BitProcess)
-                return BoardControllerLibrary64.get_sampling_rate (board_id, sampling_rate);
-            else
-                return BoardControllerLibrary32.get_sampling_rate (board_id, sampling_rate);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return BoardControllerLibrary64.get_sampling_rate(board_id, sampling_rate);
+                case LibraryEnvironment.x86:
+                    return BoardControllerLibrary32.get_sampling_rate(board_id, sampling_rate);
+                case LibraryEnvironment.Linux:
+                    return BoardControllerLibraryLinux.get_sampling_rate(board_id, sampling_rate);
+            }
+
+            return -1;
         }
 
         public static int get_package_num_channel (int board_id, int[] package_num)
         {
-            if (System.Environment.Is64BitProcess)
-                return BoardControllerLibrary64.get_package_num_channel (board_id, package_num);
-            else
-                return BoardControllerLibrary32.get_package_num_channel (board_id, package_num);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return BoardControllerLibrary64.get_package_num_channel(board_id, package_num);
+                case LibraryEnvironment.x86:
+                    return BoardControllerLibrary32.get_package_num_channel(board_id, package_num);
+                case LibraryEnvironment.Linux:
+                    return BoardControllerLibraryLinux.get_package_num_channel(board_id, package_num);
+            }
+
+            return -1;
         }
 
         public static int get_battery_channel (int board_id, int[] battery)
         {
-            if (System.Environment.Is64BitProcess)
-                return BoardControllerLibrary64.get_battery_channel (board_id, battery);
-            else
-                return BoardControllerLibrary32.get_battery_channel (board_id, battery);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return BoardControllerLibrary64.get_battery_channel(board_id, battery);
+                case LibraryEnvironment.x86:
+                    return BoardControllerLibrary32.get_battery_channel(board_id, battery);
+                case LibraryEnvironment.Linux:
+                    return BoardControllerLibraryLinux.get_battery_channel(board_id, battery);
+            }
+
+            return -1;
         }
 
         public static int get_num_rows (int board_id, int[] num_rows)
         {
-            if (System.Environment.Is64BitProcess)
-                return BoardControllerLibrary64.get_num_rows (board_id, num_rows);
-            else
-                return BoardControllerLibrary32.get_num_rows (board_id, num_rows);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return BoardControllerLibrary64.get_num_rows(board_id, num_rows);
+                case LibraryEnvironment.x86:
+                    return BoardControllerLibrary32.get_num_rows(board_id, num_rows);
+                case LibraryEnvironment.Linux:
+                    return BoardControllerLibraryLinux.get_num_rows(board_id, num_rows);
+            }
+
+            return -1;
         }
 
         public static int get_timestamp_channel (int board_id, int[] timestamp_channel)
         {
-            if (System.Environment.Is64BitProcess)
-                return BoardControllerLibrary64.get_timestamp_channel (board_id, timestamp_channel);
-            else
-                return BoardControllerLibrary32.get_timestamp_channel (board_id, timestamp_channel);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return BoardControllerLibrary64.get_timestamp_channel(board_id, timestamp_channel);
+                case LibraryEnvironment.x86:
+                    return BoardControllerLibrary32.get_timestamp_channel(board_id, timestamp_channel);
+                case LibraryEnvironment.Linux:
+                    return BoardControllerLibraryLinux.get_timestamp_channel(board_id, timestamp_channel);
+            }
+
+            return -1;
         }
 
         public static int get_eeg_names(int board_id, byte[] names, int[] len)
         {
-            if (System.Environment.Is64BitProcess)
-                return BoardControllerLibrary64.get_eeg_names(board_id, names, len);
-            else
-                return BoardControllerLibrary32.get_eeg_names(board_id, names, len);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return BoardControllerLibrary64.get_eeg_names(board_id, names, len);
+                case LibraryEnvironment.x86:
+                    return BoardControllerLibrary32.get_eeg_names(board_id, names, len);
+                case LibraryEnvironment.Linux:
+                    return BoardControllerLibraryLinux.get_eeg_names(board_id, names, len);
+            }
+
+            return -1;
         }
 
         public static int get_eeg_channels (int board_id, int[] channels, int[] len)
         {
-            if (System.Environment.Is64BitProcess)
-                return BoardControllerLibrary64.get_eeg_channels (board_id, channels, len);
-            else
-                return BoardControllerLibrary32.get_eeg_channels (board_id, channels, len);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return BoardControllerLibrary64.get_eeg_channels(board_id, channels, len);
+                case LibraryEnvironment.x86:
+                    return BoardControllerLibrary32.get_eeg_channels(board_id, channels, len);
+                case LibraryEnvironment.Linux:
+                    return BoardControllerLibraryLinux.get_eeg_channels(board_id, channels, len);
+            }
+
+            return -1;
         }
 
         public static int get_exg_channels (int board_id, int[] channels, int[] len)
         {
-            if (System.Environment.Is64BitProcess)
-                return BoardControllerLibrary64.get_exg_channels (board_id, channels, len);
-            else
-                return BoardControllerLibrary32.get_exg_channels (board_id, channels, len);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return BoardControllerLibrary64.get_exg_channels(board_id, channels, len);
+                case LibraryEnvironment.x86:
+                    return BoardControllerLibrary32.get_exg_channels(board_id, channels, len);
+                case LibraryEnvironment.Linux:
+                    return BoardControllerLibraryLinux.get_exg_channels(board_id, channels, len);
+            }
+
+            return -1;
         }
 
         public static int get_emg_channels (int board_id, int[] channels, int[] len)
         {
-            if (System.Environment.Is64BitProcess)
-                return BoardControllerLibrary64.get_emg_channels (board_id, channels, len);
-            else
-                return BoardControllerLibrary32.get_emg_channels (board_id, channels, len);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return BoardControllerLibrary64.get_emg_channels(board_id, channels, len);
+                case LibraryEnvironment.x86:
+                    return BoardControllerLibrary32.get_emg_channels(board_id, channels, len);
+                case LibraryEnvironment.Linux:
+                    return BoardControllerLibraryLinux.get_emg_channels(board_id, channels, len);
+            }
+
+            return -1;
         }
 
         public static int get_ecg_channels (int board_id, int[] channels, int[] len)
         {
-            if (System.Environment.Is64BitProcess)
-                return BoardControllerLibrary64.get_ecg_channels (board_id, channels, len);
-            else
-                return BoardControllerLibrary32.get_ecg_channels (board_id, channels, len);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return BoardControllerLibrary64.get_ecg_channels(board_id, channels, len);
+                case LibraryEnvironment.x86:
+                    return BoardControllerLibrary32.get_ecg_channels(board_id, channels, len);
+                case LibraryEnvironment.Linux:
+                    return BoardControllerLibraryLinux.get_ecg_channels(board_id, channels, len);
+            }
+
+            return -1;
         }
 
         public static int get_eog_channels (int board_id, int[] channels, int[] len)
         {
-            if (System.Environment.Is64BitProcess)
-                return BoardControllerLibrary64.get_eog_channels (board_id, channels, len);
-            else
-                return BoardControllerLibrary32.get_eog_channels (board_id, channels, len);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return BoardControllerLibrary64.get_eog_channels(board_id, channels, len);
+                case LibraryEnvironment.x86:
+                    return BoardControllerLibrary32.get_eog_channels(board_id, channels, len);
+                case LibraryEnvironment.Linux:
+                    return BoardControllerLibraryLinux.get_eog_channels(board_id, channels, len);
+            }
+
+            return -1;
         }
 
         public static int get_eda_channels (int board_id, int[] channels, int[] len)
         {
-            if (System.Environment.Is64BitProcess)
-                return BoardControllerLibrary64.get_eda_channels (board_id, channels, len);
-            else
-                return BoardControllerLibrary32.get_eda_channels (board_id, channels, len);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return BoardControllerLibrary64.get_eda_channels(board_id, channels, len);
+                case LibraryEnvironment.x86:
+                    return BoardControllerLibrary32.get_eda_channels(board_id, channels, len);
+                case LibraryEnvironment.Linux:
+                    return BoardControllerLibraryLinux.get_eda_channels(board_id, channels, len);
+            }
+
+            return -1;
         }
 
         public static int get_ppg_channels (int board_id, int[] channels, int[] len)
         {
-            if (System.Environment.Is64BitProcess)
-                return BoardControllerLibrary64.get_ppg_channels (board_id, channels, len);
-            else
-                return BoardControllerLibrary32.get_ppg_channels (board_id, channels, len);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return BoardControllerLibrary64.get_ppg_channels(board_id, channels, len);
+                case LibraryEnvironment.x86:
+                    return BoardControllerLibrary32.get_ppg_channels(board_id, channels, len);
+                case LibraryEnvironment.Linux:
+                    return BoardControllerLibraryLinux.get_ppg_channels(board_id, channels, len);
+            }
+
+            return -1;
         }
 
         public static int get_accel_channels (int board_id, int[] channels, int[] len)
         {
-            if (System.Environment.Is64BitProcess)
-                return BoardControllerLibrary64.get_accel_channels (board_id, channels, len);
-            else
-                return BoardControllerLibrary32.get_accel_channels (board_id, channels, len);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return BoardControllerLibrary64.get_accel_channels(board_id, channels, len);
+                case LibraryEnvironment.x86:
+                    return BoardControllerLibrary32.get_accel_channels(board_id, channels, len);
+                case LibraryEnvironment.Linux:
+                    return BoardControllerLibraryLinux.get_accel_channels(board_id, channels, len);
+            }
+
+            return -1;
         }
 
         public static int get_analog_channels (int board_id, int[] channels, int[] len)
         {
-            if (System.Environment.Is64BitProcess)
-                return BoardControllerLibrary64.get_analog_channels (board_id, channels, len);
-            else
-                return BoardControllerLibrary32.get_analog_channels (board_id, channels, len);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return BoardControllerLibrary64.get_analog_channels(board_id, channels, len);
+                case LibraryEnvironment.x86:
+                    return BoardControllerLibrary32.get_analog_channels(board_id, channels, len);
+                case LibraryEnvironment.Linux:
+                    return BoardControllerLibraryLinux.get_analog_channels(board_id, channels, len);
+            }
+
+            return -1;
         }
 
         public static int get_gyro_channels (int board_id, int[] channels, int[] len)
         {
-            if (System.Environment.Is64BitProcess)
-                return BoardControllerLibrary64.get_gyro_channels (board_id, channels, len);
-            else
-                return BoardControllerLibrary32.get_gyro_channels (board_id, channels, len);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return BoardControllerLibrary64.get_gyro_channels(board_id, channels, len);
+                case LibraryEnvironment.x86:
+                    return BoardControllerLibrary32.get_gyro_channels(board_id, channels, len);
+                case LibraryEnvironment.Linux:
+                    return BoardControllerLibraryLinux.get_gyro_channels(board_id, channels, len);
+            }
+
+            return -1;
         }
 
         public static int get_other_channels (int board_id, int[] channels, int[] len)
         {
-            if (System.Environment.Is64BitProcess)
-                return BoardControllerLibrary64.get_other_channels (board_id, channels, len);
-            else
-                return BoardControllerLibrary32.get_other_channels (board_id, channels, len);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return BoardControllerLibrary64.get_other_channels(board_id, channels, len);
+                case LibraryEnvironment.x86:
+                    return BoardControllerLibrary32.get_other_channels(board_id, channels, len);
+                case LibraryEnvironment.Linux:
+                    return BoardControllerLibraryLinux.get_other_channels(board_id, channels, len);
+            }
+
+            return -1;
         }
 
         public static int get_temperature_channels (int board_id, int[] channels, int[] len)
         {
-            if (System.Environment.Is64BitProcess)
-                return BoardControllerLibrary64.get_temperature_channels (board_id, channels, len);
-            else
-                return BoardControllerLibrary32.get_temperature_channels (board_id, channels, len);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return BoardControllerLibrary64.get_temperature_channels(board_id, channels, len);
+                case LibraryEnvironment.x86:
+                    return BoardControllerLibrary32.get_temperature_channels(board_id, channels, len);
+                case LibraryEnvironment.Linux:
+                    return BoardControllerLibraryLinux.get_temperature_channels(board_id, channels, len);
+            }
+
+            return -1;
         }
 
         public static int get_resistance_channels(int board_id, int[] channels, int[] len)
         {
-            if (System.Environment.Is64BitProcess)
-                return BoardControllerLibrary64.get_resistance_channels(board_id, channels, len);
-            else
-                return BoardControllerLibrary32.get_resistance_channels(board_id, channels, len);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return BoardControllerLibrary64.get_resistance_channels(board_id, channels, len);
+                case LibraryEnvironment.x86:
+                    return BoardControllerLibrary32.get_resistance_channels(board_id, channels, len);
+                case LibraryEnvironment.Linux:
+                    return BoardControllerLibraryLinux.get_resistance_channels(board_id, channels, len);
+            }
+
+            return -1;
         }
     }
 }

--- a/csharp-package/brainflow/brainflow/brainflow.csproj
+++ b/csharp-package/brainflow/brainflow/brainflow.csproj
@@ -124,6 +124,7 @@
     <Compile Include="data_handler_library.cs" />
     <Compile Include="ml_model.cs" />
     <Compile Include="ml_module_library.cs" />
+    <Compile Include="PlatformHelper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/csharp-package/brainflow/brainflow/data_handler_library.cs
+++ b/csharp-package/brainflow/brainflow/data_handler_library.cs
@@ -129,181 +129,388 @@ namespace brainflow
         public static extern int get_avg_band_powers(double[] data, int rows, int cols, int sampling_rate, int apply_filters, double[] avgs, double[] stddevs);
     }
 
+    class DataHandlerLibraryLinux
+    {
+        [DllImport("libDataHandler.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int set_log_file(string log_file);
+        [DllImport("libDataHandler.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int set_log_level(int log_level);
+        [DllImport("libDataHandler.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int perform_lowpass(double[] data, int len, int sampling_rate, double cutoff, int order, int filter_type, double ripple);
+        [DllImport("libDataHandler.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int perform_highpass(double[] data, int len, int sampling_rate, double cutoff, int order, int filter_type, double ripple);
+        [DllImport("libDataHandler.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int perform_bandpass(double[] data, int len, int sampling_rate, double center_freq, double band_width, int order, int filter_type, double ripple);
+        [DllImport("libDataHandler.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int perform_bandstop(double[] data, int len, int sampling_rate, double center_freq, double band_width, int order, int filter_type, double ripple);
+        [DllImport("libDataHandler.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int perform_rolling_filter(double[] data, int len, int period, int operation);
+        [DllImport("libDataHandler.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int perform_downsampling(double[] data, int len, int period, int operation, double[] downsampled_data);
+        [DllImport("libDataHandler.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int write_file(double[] data, int num_rows, int num_cols, string file_name, string file_mode);
+        [DllImport("libDataHandler.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int read_file(double[] data, int[] num_rows, int[] num_cols, string file_name, int max_elements);
+        [DllImport("libDataHandler.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int get_num_elements_in_file(string file_name, int[] num_elements);
+        [DllImport("libDataHandler.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int perform_wavelet_transform(double[] data, int data_len, string wavelet, int decomposition_level, double[] output_data, int[] decomposition_lengths);
+        [DllImport("libDataHandler.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int perform_inverse_wavelet_transform(double[] wavelet_coeffs, int original_data_len, string wavelet, int decomposition_level,
+                                                                    int[] decomposition_lengths, double[] output_data);
+        [DllImport("libDataHandler.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int perform_wavelet_denoising(double[] data, int data_len, string wavelet, int decomposition_level);
+        [DllImport("libDataHandler.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int perform_fft(double[] data, int data_len, int window, double[] re, double[] im);
+        [DllImport("libDataHandler.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int perform_ifft(double[] re, double[] im, int data_len, double[] data);
+        [DllImport("libDataHandler.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int get_nearest_power_of_two(int value, int[] output);
+        [DllImport("libDataHandler.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int get_psd(double[] data, int data_len, int sampling_rate, int window, double[] ampls, double[] freqs);
+        [DllImport("libDataHandler.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int get_band_power(double[] ampls, double[] freqs, int data_len, double freq_start, double freq_end, double[] res);
+        [DllImport("libDataHandler.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int get_psd_welch(double[] data, int data_len, int nfft, int overlap, int sampling_rate, int window, double[] ampls, double[] freqs);
+        [DllImport("libDataHandler.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int detrend(double[] data, int len, int operation);
+        [DllImport("libDataHandler.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int get_avg_band_powers(double[] data, int rows, int cols, int sampling_rate, int apply_filters, double[] avgs, double[] stddevs);
+    }
+
     class DataHandlerLibrary
     {
         public static int set_log_level (int log_level)
         {
-            if (System.Environment.Is64BitProcess)
-                return DataHandlerLibrary64.set_log_level (log_level);
-            else
-                return DataHandlerLibrary32.set_log_level (log_level);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return DataHandlerLibrary64.set_log_level(log_level);
+                case LibraryEnvironment.x86:
+                    return DataHandlerLibrary32.set_log_level(log_level);
+                case LibraryEnvironment.Linux:
+                    return DataHandlerLibraryLinux.set_log_level(log_level);
+            }
+
+            return -1;
         }
+
         public static int set_log_file (string log_file)
         {
-            if (System.Environment.Is64BitProcess)
-                return DataHandlerLibrary64.set_log_file (log_file);
-            else
-                return DataHandlerLibrary32.set_log_file (log_file);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return DataHandlerLibrary64.set_log_file(log_file);
+                case LibraryEnvironment.x86:
+                    return DataHandlerLibrary32.set_log_file(log_file);
+                case LibraryEnvironment.Linux:
+                    return DataHandlerLibraryLinux.set_log_file(log_file);
+            }
+
+            return -1;
         }
+
         public static int perform_lowpass (double[] data, int len, int sampling_rate, double cutoff, int order, int filter_type, double ripple)
         {
-            if (System.Environment.Is64BitProcess)
-                return DataHandlerLibrary64.perform_lowpass (data, len, sampling_rate, cutoff, order, filter_type, ripple);
-            else
-                return DataHandlerLibrary32.perform_lowpass (data, len, sampling_rate, cutoff, order, filter_type, ripple);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return DataHandlerLibrary64.perform_lowpass(data, len, sampling_rate, cutoff, order, filter_type, ripple);
+                case LibraryEnvironment.x86:
+                    return DataHandlerLibrary32.perform_lowpass(data, len, sampling_rate, cutoff, order, filter_type, ripple);
+                case LibraryEnvironment.Linux:
+                    return DataHandlerLibraryLinux.perform_lowpass(data, len, sampling_rate, cutoff, order, filter_type, ripple);
+            }
+
+            return -1;
         }
 
         public static int perform_highpass (double[] data, int len, int sampling_rate, double cutoff, int order, int filter_type, double ripple)
         {
-            if (System.Environment.Is64BitProcess)
-                return DataHandlerLibrary64.perform_highpass (data, len, sampling_rate, cutoff, order, filter_type, ripple);
-            else
-                return DataHandlerLibrary32.perform_highpass (data, len, sampling_rate, cutoff, order, filter_type, ripple);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return DataHandlerLibrary64.perform_highpass(data, len, sampling_rate, cutoff, order, filter_type, ripple);
+                case LibraryEnvironment.x86:
+                    return DataHandlerLibrary32.perform_highpass(data, len, sampling_rate, cutoff, order, filter_type, ripple);
+                case LibraryEnvironment.Linux:
+                    return DataHandlerLibraryLinux.perform_highpass(data, len, sampling_rate, cutoff, order, filter_type, ripple);
+
+            }
+
+            return -1;
         }
 
         public static int perform_bandpass (double[] data, int len, int sampling_rate, double center_freq, double band_width, int order, int filter_type, double ripple)
         {
-            if (System.Environment.Is64BitProcess)
-                return DataHandlerLibrary64.perform_bandpass (data, len, sampling_rate, center_freq, band_width, order, filter_type, ripple);
-            else
-                return DataHandlerLibrary32.perform_bandpass (data, len, sampling_rate, center_freq, band_width, order, filter_type, ripple);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return DataHandlerLibrary64.perform_bandpass(data, len, sampling_rate, center_freq, band_width, order, filter_type, ripple);
+                case LibraryEnvironment.x86:
+                    return DataHandlerLibrary32.perform_bandpass(data, len, sampling_rate, center_freq, band_width, order, filter_type, ripple);
+                case LibraryEnvironment.Linux:
+                    return DataHandlerLibraryLinux.perform_bandpass(data, len, sampling_rate, center_freq, band_width, order, filter_type, ripple);
+            }
+
+            return -1;
         }
 
         public static int perform_bandstop (double[] data, int len, int sampling_rate, double center_freq, double band_width, int order, int filter_type, double ripple)
         {
-            if (System.Environment.Is64BitProcess)
-                return DataHandlerLibrary64.perform_bandstop (data, len, sampling_rate, center_freq, band_width, order, filter_type, ripple);
-            else
-                return DataHandlerLibrary32.perform_bandstop (data, len, sampling_rate, center_freq, band_width, order, filter_type, ripple);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return DataHandlerLibrary64.perform_bandstop(data, len, sampling_rate, center_freq, band_width, order, filter_type, ripple);
+                case LibraryEnvironment.x86:
+                    return DataHandlerLibrary32.perform_bandstop(data, len, sampling_rate, center_freq, band_width, order, filter_type, ripple);
+                case LibraryEnvironment.Linux:
+                    return DataHandlerLibraryLinux.perform_bandstop(data, len, sampling_rate, center_freq, band_width, order, filter_type, ripple);
+            }
+
+            return -1;
         }
 
         public static int perform_rolling_filter (double[] data, int len, int period, int operation)
         {
-            if (System.Environment.Is64BitProcess)
-                return DataHandlerLibrary64.perform_rolling_filter (data, len, period, operation);
-            else
-                return DataHandlerLibrary32.perform_rolling_filter (data, len, period, operation);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return DataHandlerLibrary64.perform_rolling_filter(data, len, period, operation);
+                case LibraryEnvironment.x86:
+                    return DataHandlerLibrary32.perform_rolling_filter(data, len, period, operation);
+                case LibraryEnvironment.Linux:
+                    return DataHandlerLibraryLinux.perform_rolling_filter(data, len, period, operation);
+            }
+
+            return -1;
         }
 
         public static int detrend(double[] data, int len, int operation)
         {
-            if (System.Environment.Is64BitProcess)
-                return DataHandlerLibrary64.detrend(data, len, operation);
-            else
-                return DataHandlerLibrary32.detrend(data, len, operation);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return DataHandlerLibrary64.detrend(data, len, operation);
+                case LibraryEnvironment.x86:
+                    return DataHandlerLibrary32.detrend(data, len, operation);
+                case LibraryEnvironment.Linux:
+                    return DataHandlerLibraryLinux.detrend(data, len, operation);
+            }
+
+            return -1;
         }
 
         public static int perform_downsampling (double[] data, int len, int period, int operation, double[] filtered_data)
         {
-            if (System.Environment.Is64BitProcess)
-                return DataHandlerLibrary64.perform_downsampling (data, len, period, operation, filtered_data);
-            else
-                return DataHandlerLibrary32.perform_downsampling (data, len, period, operation, filtered_data);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return DataHandlerLibrary64.perform_downsampling(data, len, period, operation, filtered_data);
+                case LibraryEnvironment.x86:
+                    return DataHandlerLibrary32.perform_downsampling(data, len, period, operation, filtered_data);
+                case LibraryEnvironment.Linux:
+                    return DataHandlerLibraryLinux.perform_downsampling(data, len, period, operation, filtered_data);
+            }
+
+            return -1;
         }
 
         public static int read_file (double[] data, int[] num_rows, int[] num_cols, string file_name, int max_elements)
         {
-            if (System.Environment.Is64BitProcess)
-                return DataHandlerLibrary64.read_file (data, num_rows, num_cols, file_name, max_elements);
-            else
-                return DataHandlerLibrary32.read_file (data, num_rows, num_cols, file_name, max_elements);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return DataHandlerLibrary64.read_file(data, num_rows, num_cols, file_name, max_elements);
+                case LibraryEnvironment.x86:
+                    return DataHandlerLibrary32.read_file(data, num_rows, num_cols, file_name, max_elements);
+                case LibraryEnvironment.Linux:
+                    return DataHandlerLibraryLinux.read_file(data, num_rows, num_cols, file_name, max_elements);
+            }
+
+            return -1;
         }
 
         public static int write_file (double[] data, int num_rows, int num_cols, string file_name, string file_mode)
         {
-            if (System.Environment.Is64BitProcess)
-                return DataHandlerLibrary64.write_file (data, num_rows, num_cols, file_name, file_mode);
-            else
-                return DataHandlerLibrary32.write_file (data, num_rows, num_cols, file_name, file_mode);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return DataHandlerLibrary64.write_file(data, num_rows, num_cols, file_name, file_mode);
+                case LibraryEnvironment.x86:
+                    return DataHandlerLibrary32.write_file(data, num_rows, num_cols, file_name, file_mode);
+                case LibraryEnvironment.Linux:
+                    return DataHandlerLibraryLinux.write_file(data, num_rows, num_cols, file_name, file_mode);
+
+            }
+
+            return -1;
         }
 
         public static int get_num_elements_in_file (string file_name, int[] num_elements)
         {
-            if (System.Environment.Is64BitProcess)
-                return DataHandlerLibrary64.get_num_elements_in_file (file_name, num_elements);
-            else
-                return DataHandlerLibrary32.get_num_elements_in_file (file_name, num_elements);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return DataHandlerLibrary64.get_num_elements_in_file(file_name, num_elements);
+                case LibraryEnvironment.x86:
+                    return DataHandlerLibrary32.get_num_elements_in_file(file_name, num_elements);
+                case LibraryEnvironment.Linux:
+                    return DataHandlerLibraryLinux.get_num_elements_in_file(file_name, num_elements);
+            }
+
+            return -1;
         }
 
         public static int get_nearest_power_of_two(int value, int[] output)
         {
-            if (System.Environment.Is64BitProcess)
-                return DataHandlerLibrary64.get_nearest_power_of_two(value, output);
-            else
-                return DataHandlerLibrary32.get_nearest_power_of_two(value, output);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return DataHandlerLibrary64.get_nearest_power_of_two(value, output);
+                case LibraryEnvironment.x86:
+                    return DataHandlerLibrary32.get_nearest_power_of_two(value, output);
+                case LibraryEnvironment.Linux:
+                    return DataHandlerLibraryLinux.get_nearest_power_of_two(value, output);
+            }
+
+            return -1;
         }
 
         public static int perform_wavelet_transform (double[] data, int data_len, string wavelet, int decomposition_level, double[] output_data, int[] decomposition_lengths)
         {
-            if (System.Environment.Is64BitProcess)
-                return DataHandlerLibrary64.perform_wavelet_transform (data, data_len, wavelet, decomposition_level, output_data, decomposition_lengths);
-            else
-                return DataHandlerLibrary32.perform_wavelet_transform (data, data_len, wavelet, decomposition_level, output_data, decomposition_lengths);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return DataHandlerLibrary64.perform_wavelet_transform(data, data_len, wavelet, decomposition_level, output_data, decomposition_lengths);
+                case LibraryEnvironment.x86:
+                    return DataHandlerLibrary32.perform_wavelet_transform(data, data_len, wavelet, decomposition_level, output_data, decomposition_lengths);
+                case LibraryEnvironment.Linux:
+                    return DataHandlerLibraryLinux.perform_wavelet_transform(data, data_len, wavelet, decomposition_level, output_data, decomposition_lengths);
+            }
+
+            return -1;
         }
 
         public static int perform_inverse_wavelet_transform (double[] wavelet_coeffs, int original_data_len, string wavelet, int decomposition_level,
                                                                     int[] decomposition_lengths, double[] output_data)
         {
-            if (System.Environment.Is64BitProcess)
-                return DataHandlerLibrary64.perform_inverse_wavelet_transform (wavelet_coeffs, original_data_len, wavelet, decomposition_level, decomposition_lengths, output_data);
-            else
-                return DataHandlerLibrary32.perform_inverse_wavelet_transform (wavelet_coeffs, original_data_len, wavelet, decomposition_level, decomposition_lengths, output_data);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return DataHandlerLibrary64.perform_inverse_wavelet_transform(wavelet_coeffs, original_data_len, wavelet, decomposition_level, decomposition_lengths, output_data);
+                case LibraryEnvironment.x86:
+                    return DataHandlerLibrary32.perform_inverse_wavelet_transform(wavelet_coeffs, original_data_len, wavelet, decomposition_level, decomposition_lengths, output_data);
+                case LibraryEnvironment.Linux:
+                    return DataHandlerLibraryLinux.perform_inverse_wavelet_transform(wavelet_coeffs, original_data_len, wavelet, decomposition_level, decomposition_lengths, output_data);
+            }
+
+            return -1;
         }
 
         public static int perform_wavelet_denoising (double[] data, int data_len, string wavelet, int decomposition_level)
         {
-            if (System.Environment.Is64BitProcess)
-                return DataHandlerLibrary64.perform_wavelet_denoising (data, data_len, wavelet, decomposition_level);
-            else
-                return DataHandlerLibrary32.perform_wavelet_denoising (data, data_len, wavelet, decomposition_level);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return DataHandlerLibrary64.perform_wavelet_denoising(data, data_len, wavelet, decomposition_level);
+                case LibraryEnvironment.x86:
+                    return DataHandlerLibrary32.perform_wavelet_denoising(data, data_len, wavelet, decomposition_level);
+                case LibraryEnvironment.Linux:
+                    return DataHandlerLibraryLinux.perform_wavelet_denoising(data, data_len, wavelet, decomposition_level);
+            }
+
+            return -1;
         }
 
         public static int perform_fft (double[] data, int data_len, int window, double[] output_re, double[] output_im)
         {
-            if (System.Environment.Is64BitProcess)
-                return DataHandlerLibrary64.perform_fft (data, data_len, window, output_re, output_im);
-            else
-                return DataHandlerLibrary32.perform_fft (data, data_len, window, output_re, output_im);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return DataHandlerLibrary64.perform_fft(data, data_len, window, output_re, output_im);
+                case LibraryEnvironment.x86:
+                    return DataHandlerLibrary32.perform_fft(data, data_len, window, output_re, output_im);
+                case LibraryEnvironment.Linux:
+                    return DataHandlerLibraryLinux.perform_fft(data, data_len, window, output_re, output_im);
+            }
+
+            return -1;
         }
 
         public static int get_avg_band_powers(double[] data, int rows, int cols, int sampling_rate, int apply_filters, double[] avgs, double[] stddevs)
         {
-            if (System.Environment.Is64BitProcess)
-                return DataHandlerLibrary64.get_avg_band_powers(data, rows, cols, sampling_rate, apply_filters, avgs, stddevs);
-            else
-                return DataHandlerLibrary32.get_avg_band_powers(data, rows, cols, sampling_rate, apply_filters, avgs, stddevs);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return DataHandlerLibrary64.get_avg_band_powers(data, rows, cols, sampling_rate, apply_filters, avgs, stddevs);
+                case LibraryEnvironment.x86:
+                    return DataHandlerLibrary32.get_avg_band_powers(data, rows, cols, sampling_rate, apply_filters, avgs, stddevs);
+                case LibraryEnvironment.Linux:
+                    return DataHandlerLibraryLinux.get_avg_band_powers(data, rows, cols, sampling_rate, apply_filters, avgs, stddevs);
+            }
+
+            return -1;
         }
 
         public static int get_psd(double[] data, int data_len, int sampling_rate, int window, double[] output_ampls, double[] output_freqs)
         {
-            if (System.Environment.Is64BitProcess)
-                return DataHandlerLibrary64.get_psd(data, data_len, sampling_rate, window, output_ampls, output_freqs);
-            else
-                return DataHandlerLibrary32.get_psd(data, data_len, sampling_rate, window, output_ampls, output_freqs);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return DataHandlerLibrary64.get_psd(data, data_len, sampling_rate, window, output_ampls, output_freqs);
+                case LibraryEnvironment.x86:
+                    return DataHandlerLibrary32.get_psd(data, data_len, sampling_rate, window, output_ampls, output_freqs);
+                case LibraryEnvironment.Linux:
+                    return DataHandlerLibraryLinux.get_psd(data, data_len, sampling_rate, window, output_ampls, output_freqs);
+            }
+
+            return -1;
         }
 
         public static int get_band_power(double[] ampls, double[] freqs, int data_len, double start_freq, double stop_freq, double[] res)
         {
-            if (System.Environment.Is64BitProcess)
-                return DataHandlerLibrary64.get_band_power(ampls, freqs, data_len, start_freq, stop_freq, res);
-            else
-                return DataHandlerLibrary32.get_band_power(ampls, freqs, data_len, start_freq, stop_freq, res);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return DataHandlerLibrary64.get_band_power(ampls, freqs, data_len, start_freq, stop_freq, res);
+                case LibraryEnvironment.x86:
+                    return DataHandlerLibrary32.get_band_power(ampls, freqs, data_len, start_freq, stop_freq, res);
+                case LibraryEnvironment.Linux:
+                    return DataHandlerLibraryLinux.get_band_power(ampls, freqs, data_len, start_freq, stop_freq, res);
+            }
+
+            return -1;
         }
 
         public static int perform_ifft (double[] re, double[] im, int len, double[] data)
         {
-            if (System.Environment.Is64BitProcess)
-                return DataHandlerLibrary64.perform_ifft (re, im, len, data);
-            else
-                return DataHandlerLibrary32.perform_ifft (re, im, len, data);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return DataHandlerLibrary64.perform_ifft(re, im, len, data);
+                case LibraryEnvironment.x86:
+                    return DataHandlerLibrary32.perform_ifft(re, im, len, data);
+                case LibraryEnvironment.Linux:
+                    return DataHandlerLibraryLinux.perform_ifft(re, im, len, data);
+            }
+
+            return -1;
         }
 
         public static int get_psd_welch(double[] data, int data_len, int nfft, int overlap, int sampling_rate, int window, double[] output_ampls, double[] output_freqs)
         {
-            if (System.Environment.Is64BitProcess)
-                return DataHandlerLibrary64.get_psd_welch(data, data_len, nfft, overlap, sampling_rate, window, output_ampls, output_freqs);
-            else
-                return DataHandlerLibrary32.get_psd_welch(data, data_len, nfft, overlap, sampling_rate, window, output_ampls, output_freqs);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return DataHandlerLibrary64.get_psd_welch(data, data_len, nfft, overlap, sampling_rate, window, output_ampls, output_freqs);
+                case LibraryEnvironment.x86:
+                    return DataHandlerLibrary32.get_psd_welch(data, data_len, nfft, overlap, sampling_rate, window, output_ampls, output_freqs);
+                case LibraryEnvironment.Linux:
+                    return DataHandlerLibraryLinux.get_psd_welch(data, data_len, nfft, overlap, sampling_rate, window, output_ampls, output_freqs);
+            }
+
+            return -1;
         }
     }
 }

--- a/csharp-package/brainflow/brainflow/ml_module_library.cs
+++ b/csharp-package/brainflow/brainflow/ml_module_library.cs
@@ -49,44 +49,97 @@ namespace brainflow
         public static extern int predict(double[] data, int data_len, double[] output, string input_json);
     }
 
+    public static class MLModuleLibraryLinux
+    {
+        [DllImport("libMLModule.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int set_log_file(string log_file);
+        [DllImport("libMLModule.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int set_log_level(int log_level);
+        [DllImport("libMLModule.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int prepare(string input_json);
+        [DllImport("libMLModule.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int release(string input_json);
+        [DllImport("libMLModule.so", SetLastError = true, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int predict(double[] data, int data_len, double[] output, string input_json);
+    }
+
+
     public static class MLModuleLibrary
     {
         public static int set_log_level (int log_level)
         {
-            if (System.Environment.Is64BitProcess)
-                return MLModuleLibrary64.set_log_level (log_level);
-            else
-                return MLModuleLibrary32.set_log_level (log_level);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return MLModuleLibrary64.set_log_level(log_level);
+                case LibraryEnvironment.x86:
+                    return MLModuleLibrary32.set_log_level(log_level);
+                case LibraryEnvironment.Linux:
+                    return MLModuleLibraryLinux.set_log_level(log_level);
+            }
+
+            return -1;
         }
+
         public static int set_log_file (string log_file)
         {
-            if (System.Environment.Is64BitProcess)
-                return MLModuleLibrary64.set_log_file (log_file);
-            else
-                return MLModuleLibrary32.set_log_file (log_file);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return MLModuleLibrary64.set_log_file(log_file);
+                case LibraryEnvironment.x86:
+                    return MLModuleLibrary32.set_log_file(log_file);
+                case LibraryEnvironment.Linux:
+                    return MLModuleLibraryLinux.set_log_file(log_file);
+            }
+
+            return -1;
         }
+
         public static int prepare (string input_json)
         {
-            if (System.Environment.Is64BitProcess)
-                return MLModuleLibrary64.prepare (input_json);
-            else
-                return MLModuleLibrary32.prepare (input_json);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return MLModuleLibrary64.prepare(input_json);
+                case LibraryEnvironment.x86:
+                    return MLModuleLibrary32.prepare(input_json);
+                case LibraryEnvironment.Linux:
+                    return MLModuleLibraryLinux.prepare(input_json);
+
+            }
+
+            return -1;
         }
 
         public static int release (string input_json)
         {
-            if (System.Environment.Is64BitProcess)
-                return MLModuleLibrary64.release (input_json);
-            else
-                return MLModuleLibrary32.release (input_json);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return MLModuleLibrary64.release(input_json);
+                case LibraryEnvironment.x86:
+                    return MLModuleLibrary32.release(input_json);
+                case LibraryEnvironment.Linux:
+                    return MLModuleLibraryLinux.release(input_json);
+            }
+
+            return -1;
         }
 
         public static int predict (double[] data, int data_len, double[] output, string input_json)
         {
-            if (System.Environment.Is64BitProcess)
-                return MLModuleLibrary64.predict (data, data_len,output, input_json);
-            else
-                return MLModuleLibrary32.predict (data, data_len, output, input_json);
+            switch (PlatformHelper.GetLibraryEnvironment())
+            {
+                case LibraryEnvironment.x64:
+                    return MLModuleLibrary64.predict(data, data_len, output, input_json);
+                case LibraryEnvironment.x86:
+                    return MLModuleLibrary32.predict(data, data_len, output, input_json);
+                case LibraryEnvironment.Linux:
+                    return MLModuleLibraryLinux.predict(data, data_len, output, input_json);
+            }
+
+            return -1;
         }
     }
 }


### PR DESCRIPTION
1) Added PlatformHelper.cs
- Provides a single efficient place to determine correct library environment

2) Modified  board_controller_library.cs and data_handler_library.cs and ml_module_library.cs
- *LibraryLinux was added to mirror *Library32 and *Library64 pattern
- Functions were modified to switch on LibraryEnvironment instead of if(64){}else{}

Ran all C# test projects on:
- Windows = all tests pass
- Linux 64 bit = all tests pass
- Linux 32 bit ARM (Raspbian Buster) = one test fails to run to completion
(however, the analogous  C++ test also fails in same way when run on Raspbian Buster)

Please see this report for details and proof of tests run:  https://docs.google.com/document/d/e/2PACX-1vQcvG-C1hVSkCLoHbMSsg8918PqG82ONWmkRDfdvXrQj6RBujD3YWY8E5pUJHj8_Tr8aY6-C0Q16q--/pub